### PR TITLE
refactor!: rework app router relationship

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xpresso"
-version = "0.7.3"
+version = "0.8.0"
 description = "A developer centric, performant Python web framework"
 authors = ["Adrian Garcia Badaracco <adrian@adriangb.com>"]
 readme = "README.md"

--- a/xpresso/applications.py
+++ b/xpresso/applications.py
@@ -42,7 +42,7 @@ ExceptionHandlers = typing.Mapping[
 
 def _include_error_middleware(
     debug: bool,
-    user_middleware: typing.Sequence[Middleware],
+    user_middleware: typing.Iterable[Middleware],
     exception_handlers: ExceptionHandlers,
 ) -> typing.Sequence[Middleware]:
     # user's exception handlers come last so that they can override
@@ -68,8 +68,21 @@ def _include_error_middleware(
 
 
 class App:
+    __slots__ = (
+        "router",
+        "openapi",
+        "state",
+        "container",
+        "openapi_version",
+        "openapi_info",
+        "servers",
+        "_lifespan_ctx",
+        "_debug",
+        "_setup_run",
+    )
+
     router: Router
-    openapi: typing.Optional[openapi_models.OpenAPI] = None
+    openapi: typing.Optional[openapi_models.OpenAPI]
     state: State
     container: BaseContainer
 
@@ -142,6 +155,7 @@ class App:
             description=description,
         )
         self.servers = servers
+        self.openapi = None
 
     async def _lifespan(
         self,

--- a/xpresso/applications.py
+++ b/xpresso/applications.py
@@ -1,3 +1,4 @@
+import traceback
 import typing
 from contextlib import asynccontextmanager
 
@@ -5,7 +6,6 @@ import starlette.types
 from di import AsyncExecutor, BaseContainer
 from di.api.dependencies import DependantBase
 from di.api.providers import DependencyProviderType
-from starlette.applications import Starlette
 from starlette.datastructures import State
 from starlette.middleware import Middleware
 from starlette.middleware.errors import ServerErrorMiddleware
@@ -32,19 +32,45 @@ from xpresso.routing.router import Router
 from xpresso.routing.websockets import WebSocketRoute
 from xpresso.security._dependants import Security
 
-ExceptionHandler = typing.Callable[[Request, typing.Type[BaseException]], Response]
+ExceptionHandler = typing.Callable[
+    [Request, Exception], typing.Union[Response, typing.Awaitable[Response]]
+]
+ExceptionHandlers = typing.Mapping[
+    typing.Union[typing.Type[Exception], int], ExceptionHandler
+]
 
 
-class App(Starlette):
+def _include_error_middleware(
+    debug: bool,
+    user_middleware: typing.Sequence[Middleware],
+    exception_handlers: ExceptionHandlers,
+) -> typing.Sequence[Middleware]:
+    # user's exception handlers come last so that they can override
+    # the default exception handlers
+    exception_handlers = {
+        RequestValidationError: validation_exception_handler,
+        HTTPException: http_exception_handler,
+        **exception_handlers,
+    }
+
+    error_handler = None
+    for key, value in exception_handlers.items():
+        if key in (500, Exception):
+            error_handler = value
+        else:
+            exception_handlers[key] = value
+
+    return (
+        Middleware(ServerErrorMiddleware, handler=error_handler, debug=debug),
+        *user_middleware,
+        Middleware(ExceptionMiddleware, handlers=exception_handlers, debug=debug),
+    )
+
+
+class App:
     router: Router
-    middleware_stack: starlette.types.ASGIApp
     openapi: typing.Optional[openapi_models.OpenAPI] = None
-    _debug: bool
     state: State
-    exception_handlers: typing.Mapping[
-        typing.Union[int, typing.Type[Exception]], ExceptionHandler
-    ]
-    user_middleware: typing.Sequence[Middleware]
     container: BaseContainer
 
     def __init__(
@@ -55,12 +81,7 @@ class App(Starlette):
         dependencies: typing.Optional[typing.List[Dependant]] = None,
         debug: bool = False,
         middleware: typing.Optional[typing.Sequence[Middleware]] = None,
-        exception_handlers: typing.Optional[
-            typing.Dict[
-                typing.Union[int, typing.Type[Exception]],
-                ExceptionHandler,
-            ]
-        ] = None,
+        exception_handlers: typing.Optional[ExceptionHandlers] = None,
         lifespan: typing.Optional[DependencyProviderType[None]] = None,
         openapi_version: str = "3.0.3",
         title: str = "API",
@@ -70,19 +91,6 @@ class App(Starlette):
         docs_url: typing.Optional[str] = "/docs",
         servers: typing.Optional[typing.Iterable[openapi_models.Server]] = None,
     ) -> None:
-        routes = list(routes or [])
-        routes.extend(
-            self._get_doc_routes(
-                openapi_url=openapi_url,
-                docs_url=docs_url,
-            )
-        )
-        self._debug = debug
-        self.state = State()
-        self.exception_handlers = (
-            {} if exception_handlers is None else dict(exception_handlers)
-        )
-
         self.container = container or BaseContainer(
             scopes=("app", "connection", "operation")
         )
@@ -90,7 +98,7 @@ class App(Starlette):
         self._setup_run = False
 
         @asynccontextmanager
-        async def lifespan_ctx(app: Starlette) -> typing.AsyncGenerator[None, None]:
+        async def lifespan_ctx() -> typing.AsyncGenerator[None, None]:
             self._setup()
             self._setup_run = True
             original_container = self.container
@@ -108,11 +116,25 @@ class App(Starlette):
                     self.container = original_container
                     self._setup_run = False
 
-        self.router = Router(routes, lifespan=lifespan_ctx, dependencies=dependencies)
-        self.user_middleware = [] if middleware is None else list(middleware)
-        self.middleware_stack = self.build_middleware_stack()  # type: ignore
-        self.add_exception_handler(RequestValidationError, validation_exception_handler)  # type: ignore
-        self.add_exception_handler(HTTPException, http_exception_handler)  # type: ignore
+        self._lifespan_ctx = lifespan_ctx
+
+        self._debug = debug
+        self.state = State()
+
+        routes = list(routes or [])
+        routes.extend(
+            self._get_doc_routes(
+                openapi_url=openapi_url,
+                docs_url=docs_url,
+            )
+        )
+        middleware = _include_error_middleware(
+            debug=debug,
+            user_middleware=middleware or (),
+            exception_handlers=exception_handlers or {},
+        )
+        self.router = Router(routes, dependencies=dependencies, middleware=middleware)
+
         self.openapi_version = openapi_version
         self.openapi_info = openapi_models.Info(
             title=title,
@@ -121,27 +143,32 @@ class App(Starlette):
         )
         self.servers = servers
 
-    def build_middleware_stack(self) -> starlette.types.ASGIApp:
-        debug = self.debug
-        error_handler = None
-        exception_handlers = {}
-
-        for key, value in self.exception_handlers.items():
-            if key in (500, Exception):
-                error_handler = value
+    async def _lifespan(
+        self,
+        scope: starlette.types.Scope,
+        receive: starlette.types.Receive,
+        send: starlette.types.Send,
+    ) -> None:
+        """
+        Handle ASGI lifespan messages, which allows us to manage application
+        startup and shutdown events.
+        """
+        started = False
+        await receive()
+        try:
+            async with self._lifespan_ctx():
+                await send({"type": "lifespan.startup.complete"})
+                started = True
+                await receive()
+        except BaseException:
+            exc_text = traceback.format_exc()
+            if started:
+                await send({"type": "lifespan.shutdown.failed", "message": exc_text})
             else:
-                exception_handlers[key] = value
-
-        middleware = (
-            Middleware(ServerErrorMiddleware, handler=error_handler, debug=debug),
-            *self.user_middleware,
-            Middleware(ExceptionMiddleware, handlers=exception_handlers, debug=debug),
-        )
-
-        app = self.router
-        for cls, options in reversed(middleware):
-            app = cls(app=app, **options)
-        return app
+                await send({"type": "lifespan.startup.failed", "message": exc_text})
+            raise
+        else:
+            await send({"type": "lifespan.shutdown.complete"})
 
     async def __call__(
         self,
@@ -150,7 +177,9 @@ class App(Starlette):
         send: starlette.types.Send,
     ) -> None:
         self._setup()
-        if scope["type"] == "http" or scope["type"] == "websocket":
+        scope["app"] = self
+        scope_type = scope["type"]
+        if scope_type == "http" or scope_type == "websocket":
             extensions = scope.get("extensions", None) or {}
             scope["extensions"] = extensions
             xpresso_scope = extensions.get("xpresso", None)
@@ -161,10 +190,13 @@ class App(Starlette):
                         "response_sent": False,
                     }
                     extensions["xpresso"] = xpresso_asgi_extension
-                    await super().__call__(scope, receive, send)
+                    await self.router(scope, receive, send)
                     xpresso_asgi_extension["response_sent"] = True
                     return
-        await super().__call__(scope, receive, send)
+        elif scope_type == "lifespan":
+            await self._lifespan(scope, receive, send)
+            return
+        await self.router(scope, receive, send)
 
     def _setup(self) -> None:
         if self._setup_run:
@@ -247,7 +279,7 @@ class App(Starlette):
             openapi_url = openapi_url
 
             async def swagger_ui_html(req: Request) -> HTMLResponse:
-                root_path: str = req.scope.get("root_path", "").rstrip("/")
+                root_path: str = req.scope.get("root_path", "").rstrip("/")  # type: ignore  # for Pylance
                 full_openapi_url = root_path + openapi_url  # type: ignore[operator]
                 return get_swagger_ui_html(
                     openapi_url=full_openapi_url,

--- a/xpresso/exception_handlers.py
+++ b/xpresso/exception_handlers.py
@@ -8,7 +8,8 @@ from xpresso.exceptions import RequestValidationError
 encoder = JsonableEncoder()
 
 
-async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+async def http_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    assert isinstance(exc, HTTPException)
     headers = getattr(exc, "headers", None)
     if headers:
         return JSONResponse(
@@ -19,8 +20,9 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> JSONRe
 
 
 async def validation_exception_handler(
-    request: Request, exc: RequestValidationError
+    request: Request, exc: Exception
 ) -> JSONResponse:
+    assert isinstance(exc, RequestValidationError)
     return JSONResponse(
         encoder({"detail": exc.errors()}),
         status_code=exc.status_code,

--- a/xpresso/responses.py
+++ b/xpresso/responses.py
@@ -41,7 +41,7 @@ def get_response(request: Request) -> Response:
 
 
 def set_response(request: Request, response: Response) -> None:
-    xpresso_scope: XpressoASGIExtension = request.scope["extensions"]["xpresso"]
+    xpresso_scope: XpressoASGIExtension = request.scope["extensions"]["xpresso"]  # type: ignore  # for Pylance
     if xpresso_scope["response_sent"]:
         raise XpressoError(
             'set_response() can only be used from "operation" scoped dependendencies'

--- a/xpresso/routing/router.py
+++ b/xpresso/routing/router.py
@@ -125,14 +125,14 @@ class Router:
 
         return self._default(scope, receive, send)
 
-    async def __call__(
+    def __call__(
         self,
         scope: starlette.types.Scope,
         receive: starlette.types.Receive,
         send: starlette.types.Send,
-    ) -> None:
+    ) -> typing.Awaitable[None]:
 
         if "router" not in scope:
             scope["router"] = self
 
-        await self._app(scope, receive, send)  # type: ignore
+        return self._app(scope, receive, send)  # type: ignore

--- a/xpresso/routing/router.py
+++ b/xpresso/routing/router.py
@@ -135,4 +135,4 @@ class Router:
         if "router" not in scope:
             scope["router"] = self
 
-        return self._app(scope, receive, send)  # type: ignore
+        return self._app(scope, receive, send)  # type: ignore[call-arg,misc,arg-type]


### PR DESCRIPTION
This change:

- Moves the responsibility of middleware to Router, effectively enabling Router-level middleware that will work with `Mount`, `Host`, etc.
- Moves the responsibility of lifespans into `App` since there can only ever be 1 lifespan and there can only be 1 `App`.

As part of this, `App` no longer inherits from `Starlette` and `Router` no longer inherits from its counterpart in Starlette.
This both simplifies things and complicates them a bit, but it does give us the opportunity to do a bit of cleanup and performance optimization (slots, removing lifespan wrappers and making routing sans-io)

There are obviously cons to this though. I might let this stew a bit and see.


Here are the benchmark numbers using the benchmarks in `/benchmark`:

|           | /simple | /fast_deps | /slow_deps |
|-----------|---------|------------|------------|
| main      | 2.19    | 1.44       | 0.16       |
| this      | 2.40    | 1.38       | 0.16       |
| starlette | 4.47    |            |            |
| fastapi   | 2.76    | 0.63       | .08        |

So it looks like this is a pretty solid +10% performance boost for simple scenarios