### PR TITLE
feat/refactor!: router-level middleware, support for lifespans on mounted apps

### DIFF
--- a/docs_src/tutorial/lifespan.py
+++ b/docs_src/tutorial/lifespan.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import AsyncGenerator
 
@@ -13,6 +14,7 @@ class Config:
 ConfigDep = Annotated[Config, Dependant(scope="app")]
 
 
+@asynccontextmanager
 async def lifespan(config: ConfigDep) -> AsyncGenerator[None, None]:
     print(config.token)
     yield

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xpresso"
-version = "0.7.3"
+version = "0.8.0"
 description = "A developer centric, performant Python web framework"
 authors = ["Adrian Garcia Badaracco <adrian@adriangb.com>"]
 readme = "README.md"

--- a/tests/test_dependency_injection.py
+++ b/tests/test_dependency_injection.py
@@ -1,14 +1,11 @@
-import sys
-
-if sys.version_info < (3, 9):
-    from typing_extensions import Annotated
-else:
-    from typing import Annotated
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
 
 from starlette.responses import Response
 from starlette.testclient import TestClient
 
 from xpresso import App, Dependant, Operation, Path
+from xpresso.typing import Annotated
 
 
 def test_router_route_dependencies() -> None:
@@ -44,8 +41,12 @@ def test_lifespan_dependencies() -> None:
     class Test:
         ...
 
-    async def lifespan(t: Annotated[Test, Dependant(scope="app")]) -> None:
+    @asynccontextmanager
+    async def lifespan(
+        t: Annotated[Test, Dependant(scope="app")]
+    ) -> AsyncIterator[None]:
         app.state.t = t  # type: ignore[has-type]
+        yield
 
     async def endpoint(t: Annotated[Test, Dependant(scope="app")]) -> Response:
         assert app.state.t is t  # type: ignore[has-type]

--- a/tests/test_docs/tutorial/routing/test_tutorial002.py
+++ b/tests/test_docs/tutorial/routing/test_tutorial002.py
@@ -12,7 +12,7 @@ def test_openapi() -> None:
             "/v1/items": {
                 "get": {
                     "responses": {"404": {"description": "Item not found"}},
-                    "tags": ["read", "v1", "items"],
+                    "tags": ["v1", "items", "read"],
                     "summary": "List all items",
                     "description": "The **items** operation",
                     "deprecated": True,
@@ -32,7 +32,7 @@ def test_openapi() -> None:
                             },
                         },
                     },
-                    "tags": ["write", "v1", "items"],
+                    "tags": ["v1", "items", "write"],
                     "description": "Documentation from docstrings!\n    You can use any valid markdown, for example lists:\n\n    - Point 1\n    - Point 2\n    ",
                     "requestBody": {
                         "content": {

--- a/tests/test_exception_handlers.py
+++ b/tests/test_exception_handlers.py
@@ -1,0 +1,42 @@
+from xpresso import App, HTTPException, Path, Request
+from xpresso.responses import JSONResponse
+from xpresso.testclient import TestClient
+
+
+def test_override_base_error_handler() -> None:
+    async def custom_server_error_from_exception(request: Request, exc: Exception):
+        return JSONResponse(
+            {"detail": "Custom Server Error from Exception"}, status_code=500
+        )
+
+    async def raise_exception() -> None:
+        raise Exception
+
+    async def custom_server_error_from_500(request: Request, exc: Exception):
+        return JSONResponse(
+            {"detail": "Custom Server Error from HTTPException(500)"}, status_code=500
+        )
+
+    async def raise_500() -> None:
+        raise HTTPException(500)
+
+    app = App(
+        routes=[
+            Path("/raise-exception", get=raise_exception),
+            Path("/raise-500", get=raise_500),
+        ],
+        exception_handlers={
+            Exception: custom_server_error_from_exception,
+            500: custom_server_error_from_500,
+        },
+    )
+
+    client = TestClient(app)
+
+    resp = client.get("/raise-exception")
+    assert resp.status_code == 500, resp.content
+    assert resp.json() == {"detail": "Custom Server Error from Exception"}
+
+    resp = client.get("/raise-500")
+    assert resp.status_code == 500, resp.content
+    assert resp.json() == {"detail": "Custom Server Error from HTTPException(500)"}

--- a/tests/test_lifespans.py
+++ b/tests/test_lifespans.py
@@ -1,9 +1,7 @@
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, List
 
-import pytest
-
-from xpresso import App, Dependant
+from xpresso import App, Dependant, Router
 from xpresso.routing.mount import Mount
 from xpresso.testclient import TestClient
 
@@ -17,49 +15,24 @@ def test_lifespan_mounted_app() -> None:
         counter.append(1)
         yield
 
-    app = App(
-        routes=[Mount("/mounted-app", app=App(lifespan=lifespan))], lifespan=lifespan
+    counter = Counter()
+
+    inner_app = App(lifespan=lifespan)
+    inner_app.container.register_by_type(
+        Dependant(lambda: counter, scope="app"), Counter
     )
 
-    counter = Counter()
+    app = App(
+        routes=[
+            Mount("/mounted-app", app=inner_app),
+            Mount("/mounted-router", app=Router([], lifespan=lifespan)),
+        ],
+        lifespan=lifespan,
+    )
+
     app.container.register_by_type(Dependant(lambda: counter, scope="app"), Counter)
 
     with TestClient(app):
         pass
 
-    assert counter == [1, 1]
-
-
-def test_lifespan_raises_exception_startup() -> None:
-    class SomeExc(Exception):
-        pass
-
-    @asynccontextmanager
-    async def lifespan() -> AsyncIterator[None]:
-        raise SomeExc
-        yield  # type: ignore[unreachable]
-
-    app = App(lifespan=lifespan)
-
-    client = TestClient(app)
-
-    with pytest.raises(SomeExc):
-        client.__enter__()
-
-
-def test_lifespan_raises_exception_shutdown() -> None:
-    class SomeExc(Exception):
-        pass
-
-    @asynccontextmanager
-    async def lifespan() -> AsyncIterator[None]:
-        yield
-        raise SomeExc
-
-    app = App(lifespan=lifespan)
-
-    client = TestClient(app)
-
-    client = client.__enter__()
-    with pytest.raises(SomeExc):
-        client.__exit__(None, None, None)
+    assert counter == [1, 1, 1]

--- a/tests/test_lifespans.py
+++ b/tests/test_lifespans.py
@@ -1,0 +1,65 @@
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, List
+
+import pytest
+
+from xpresso import App, Dependant
+from xpresso.routing.mount import Mount
+from xpresso.testclient import TestClient
+
+
+def test_lifespan_mounted_app() -> None:
+    class Counter(List[int]):
+        pass
+
+    @asynccontextmanager
+    async def lifespan(counter: Counter) -> AsyncIterator[None]:
+        counter.append(1)
+        yield
+
+    app = App(
+        routes=[Mount("/mounted-app", app=App(lifespan=lifespan))], lifespan=lifespan
+    )
+
+    counter = Counter()
+    app.container.register_by_type(Dependant(lambda: counter, scope="app"), Counter)
+
+    with TestClient(app):
+        pass
+
+    assert counter == [1, 1]
+
+
+def test_lifespan_raises_exception_startup() -> None:
+    class SomeExc(Exception):
+        pass
+
+    @asynccontextmanager
+    async def lifespan() -> AsyncIterator[None]:
+        raise SomeExc
+        yield  # type: ignore[unreachable]
+
+    app = App(lifespan=lifespan)
+
+    client = TestClient(app)
+
+    with pytest.raises(SomeExc):
+        client.__enter__()
+
+
+def test_lifespan_raises_exception_shutdown() -> None:
+    class SomeExc(Exception):
+        pass
+
+    @asynccontextmanager
+    async def lifespan() -> AsyncIterator[None]:
+        yield
+        raise SomeExc
+
+    app = App(lifespan=lifespan)
+
+    client = TestClient(app)
+
+    client = client.__enter__()
+    with pytest.raises(SomeExc):
+        client.__exit__(None, None, None)

--- a/tests/test_routing/test_mounts.py
+++ b/tests/test_routing/test_mounts.py
@@ -1,7 +1,9 @@
 """Tests for experimental OpenAPI inspired routing"""
 from typing import Any, Dict
 
-from xpresso import App, FromPath, Path
+from di import BaseContainer
+
+from xpresso import App, Dependant, FromPath, Path
 from xpresso.routing.mount import Mount
 from xpresso.testclient import TestClient
 
@@ -126,7 +128,7 @@ def test_openapi_routing_for_mounted_path() -> None:
     assert resp.json() == expected_openapi
 
 
-def test_xpresso_app_as_app_param_to_mount_routing() -> None:
+def test_mounted_xpresso_app_routing() -> None:
     # not a use case we advertise
     # but we want to know what the behavior is
     app = App(
@@ -152,7 +154,7 @@ def test_xpresso_app_as_app_param_to_mount_routing() -> None:
     assert resp.json() == 124
 
 
-def test_xpresso_app_as_app_param_to_mount_openapi() -> None:
+def test_mounted_xpresso_app_openapi() -> None:
     # not a use case we advertise
     # but we want to know what the behavior is
     app = App(
@@ -176,9 +178,170 @@ def test_xpresso_app_as_app_param_to_mount_openapi() -> None:
     expected_openapi: Dict[str, Any] = {
         "openapi": "3.0.3",
         "info": {"title": "API", "version": "0.1.0"},
-        "paths": {},
+        "paths": {
+            "/mount/{number}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"title": "Response", "type": "integer"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "parameters": [
+                        {
+                            "required": True,
+                            "style": "simple",
+                            "explode": False,
+                            "schema": {"title": "Number", "type": "integer"},
+                            "name": "number",
+                            "in": "path",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "oneOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
     }
 
     resp = client.get("/openapi.json")
     assert resp.status_code == 200, resp.content
     assert resp.json() == expected_openapi
+
+
+def test_mounted_xpresso_app_dependencies_isolated_containers() -> None:
+    # not a use case we advertise
+    # but we want to know what the behavior is
+
+    class Thing:
+        def __init__(self, value: str = "default") -> None:
+            self.value = value
+
+    async def endpoint(thing: Thing) -> str:
+        return thing.value
+
+    inner_app = App(
+        routes=[
+            Path(
+                path="/",
+                get=endpoint,
+            )
+        ],
+    )
+
+    app = App(
+        routes=[
+            Mount(
+                path="/mount",
+                app=inner_app,
+            ),
+            Path("/top-level", get=endpoint),
+        ]
+    )
+
+    app.container.register_by_type(
+        Dependant(lambda: Thing("injected")),
+        Thing,
+    )
+
+    client = TestClient(app)
+
+    resp = client.get("/top-level")
+    assert resp.status_code == 200, resp.content
+    assert resp.json() == "injected"
+
+    resp = client.get("/mount")
+    assert resp.status_code == 200, resp.content
+    assert resp.json() == "default"
+
+
+def test_mounted_xpresso_app_dependencies_shared_containers() -> None:
+    # not a use case we advertise
+    # but we want to know what the behavior is
+
+    class Thing:
+        def __init__(self, value: str = "default") -> None:
+            self.value = value
+
+    async def endpoint(thing: Thing) -> str:
+        return thing.value
+
+    container = BaseContainer(scopes=("app", "connection", "operation"))
+    container.register_by_type(
+        Dependant(lambda: Thing("injected")),
+        Thing,
+    )
+
+    inner_app = App(
+        routes=[
+            Path(
+                path="/",
+                get=endpoint,
+            )
+        ],
+        container=container,
+    )
+
+    app = App(
+        routes=[
+            Mount(
+                path="/mount",
+                app=inner_app,
+            ),
+            Path("/top-level", get=endpoint),
+        ],
+        container=container,
+    )
+
+    client = TestClient(app)
+
+    resp = client.get("/top-level")
+    assert resp.status_code == 200, resp.content
+    assert resp.json() == "injected"
+
+    resp = client.get("/mount")
+    assert resp.status_code == 200, resp.content
+    assert resp.json() == "injected"

--- a/tests/test_routing/test_router.py
+++ b/tests/test_routing/test_router.py
@@ -1,0 +1,94 @@
+from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+
+from xpresso import App, Path, Request, Response, Router
+from xpresso.routing.mount import Mount
+from xpresso.testclient import TestClient
+
+
+def test_router_middleware() -> None:
+    async def endpoint() -> None:
+        ...
+
+    class AddCustomHeaderMiddleware(BaseHTTPMiddleware):
+        async def dispatch(
+            self, request: Request, call_next: RequestResponseEndpoint
+        ) -> Response:
+            resp = await call_next(request)
+            resp.headers["X-Custom"] = "123"
+            return resp
+
+    app = App(
+        routes=[
+            Mount(
+                "/with-middleware",
+                app=Router(
+                    routes=[
+                        Path(
+                            "/",
+                            get=endpoint,
+                        )
+                    ],
+                    middleware=[Middleware(AddCustomHeaderMiddleware)],
+                ),
+            ),
+            Mount(
+                "/without-middleware",
+                app=Router(
+                    routes=[
+                        Path(
+                            "/",
+                            get=endpoint,
+                        )
+                    ]
+                ),
+            ),
+        ]
+    )
+
+    client = TestClient(app)
+
+    resp = client.get("/with-middleware/")
+    assert resp.status_code == 200, resp.content
+    assert resp.headers["X-Custom"] == "123"
+
+    resp = client.get("/without-middleware/")
+    assert resp.status_code == 200, resp.content
+    assert "X-Custom" not in resp.headers
+
+
+def test_router_middleware_modify_path() -> None:
+    async def endpoint() -> None:
+        ...
+
+    class RerouteMiddleware(BaseHTTPMiddleware):
+        async def dispatch(
+            self, request: Request, call_next: RequestResponseEndpoint
+        ) -> Response:
+            request.scope["path"] = request.scope["path"].replace("bad", "good")
+            return await call_next(request)
+
+    app = App(
+        routes=[
+            Mount(
+                "/",
+                app=Router(
+                    routes=[
+                        Path(
+                            "/good",
+                            get=endpoint,
+                        )
+                    ],
+                    middleware=[Middleware(RerouteMiddleware)],
+                ),
+            ),
+        ]
+    )
+
+    client = TestClient(app)
+
+    resp = client.get("/bad")
+    assert resp.status_code == 200, resp.content
+
+    resp = client.get("/very-bad")
+    assert resp.status_code == 404, resp.content

--- a/xpresso/_utils/deprecation.py
+++ b/xpresso/_utils/deprecation.py
@@ -1,0 +1,12 @@
+import typing
+
+
+def not_supported(method: str) -> typing.Callable[..., typing.Any]:
+    """Marks a method as not supported
+    Used to hard-deprecate things from Starlette
+    """
+
+    def raise_error(*args: typing.Any, **kwargs: typing.Any) -> typing.NoReturn:
+        raise NotImplementedError(f"Use of {method} is not supported")
+
+    return raise_error

--- a/xpresso/_utils/routing.py
+++ b/xpresso/_utils/routing.py
@@ -11,15 +11,13 @@ from starlette.routing import BaseRoute, Mount
 from starlette.routing import Router as StarletteRouter
 
 from xpresso.routing.pathitem import Path
-from xpresso.routing.router import Router as XpressoRouter
 from xpresso.routing.websockets import WebSocketRoute
-
-Lifespan = typing.Callable[..., typing.AsyncContextManager[None]]
 
 
 class App(Protocol):
-    lifespan: typing.Optional[Lifespan]
-    router: XpressoRouter
+    @property
+    def router(self) -> StarletteRouter:
+        ...
 
 
 AppType = typing.TypeVar("AppType", bound=App)

--- a/xpresso/applications.py
+++ b/xpresso/applications.py
@@ -112,7 +112,7 @@ class App:
         self.container = container or BaseContainer(
             scopes=("app", "connection", "operation")
         )
-        register_framework_dependencies(self.container, self)
+        register_framework_dependencies(self.container)
         self._setup_run = False
 
         @asynccontextmanager

--- a/xpresso/dependencies/utils.py
+++ b/xpresso/dependencies/utils.py
@@ -12,7 +12,7 @@ from xpresso.dependencies.models import Dependant
 T = typing.TypeVar("T")
 
 
-def register_framework_dependencies(container: BaseContainer, app: typing.Any):
+def register_framework_dependencies(container: BaseContainer):
     container.register_by_type(
         Dependant(Request, scope="connection", wire=False),
         Request,
@@ -44,12 +44,4 @@ def register_framework_dependencies(container: BaseContainer, app: typing.Any):
             wire=False,
         ),
         BackgroundTasks,
-    )
-    container.register_by_type(
-        Dependant(
-            lambda: app,
-            scope="app",
-            wire=False,
-        ),
-        type(app),
     )

--- a/xpresso/dependencies/utils.py
+++ b/xpresso/dependencies/utils.py
@@ -12,7 +12,7 @@ from xpresso.dependencies.models import Dependant
 T = typing.TypeVar("T")
 
 
-def register_framework_dependencies(container: BaseContainer):
+def register_framework_dependencies(container: BaseContainer, app: typing.Any):
     container.register_by_type(
         Dependant(Request, scope="connection", wire=False),
         Request,
@@ -44,4 +44,12 @@ def register_framework_dependencies(container: BaseContainer):
             wire=False,
         ),
         BackgroundTasks,
+    )
+    container.register_by_type(
+        Dependant(
+            lambda: app,
+            scope="app",
+            wire=False,
+        ),
+        type(app),
     )

--- a/xpresso/exception_handlers.py
+++ b/xpresso/exception_handlers.py
@@ -8,7 +8,8 @@ from xpresso.exceptions import RequestValidationError
 encoder = JsonableEncoder()
 
 
-async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+async def http_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    assert isinstance(exc, HTTPException)
     headers = getattr(exc, "headers", None)
     if headers:
         return JSONResponse(
@@ -19,8 +20,9 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> JSONRe
 
 
 async def validation_exception_handler(
-    request: Request, exc: RequestValidationError
+    request: Request, exc: Exception
 ) -> JSONResponse:
+    assert isinstance(exc, RequestValidationError)
     return JSONResponse(
         encoder({"detail": exc.errors()}),
         status_code=exc.status_code,

--- a/xpresso/routing/router.py
+++ b/xpresso/routing/router.py
@@ -5,18 +5,9 @@ from starlette.routing import BaseRoute
 from starlette.routing import Router as StarletteRouter
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+from xpresso._utils.deprecation import not_supported
 from xpresso.dependencies.models import Dependant
 from xpresso.responses import Responses
-
-
-def _not_supported(method: str) -> typing.Callable[..., typing.Any]:
-    def raise_error(*args: typing.Any, **kwargs: typing.Any) -> typing.NoReturn:
-        raise NotImplementedError(
-            f"Use of Router.{method} is deprecated."
-            " Use Router(routes=[...]) instead."
-        )
-
-    return raise_error
 
 
 class Router(StarletteRouter):
@@ -30,6 +21,9 @@ class Router(StarletteRouter):
         middleware: typing.Optional[
             typing.Sequence[starlette.middleware.Middleware]
         ] = None,
+        lifespan: typing.Optional[
+            typing.Callable[..., typing.AsyncContextManager[None]]
+        ] = None,
         redirect_slashes: bool = True,
         default: typing.Optional[ASGIApp] = None,
         dependencies: typing.Optional[typing.List[Dependant]] = None,
@@ -41,7 +35,7 @@ class Router(StarletteRouter):
             routes=list(routes),
             redirect_slashes=redirect_slashes,
             default=default,  # type: ignore
-            lifespan=None,  # type: ignore
+            lifespan=lifespan,  # type: ignore
         )
         self.dependencies = list(dependencies or [])
         self.tags = list(tags or [])
@@ -64,11 +58,11 @@ class Router(StarletteRouter):
 
         await self._app(scope, receive, send)  # type: ignore[arg-type,call-arg,misc]
 
-    mount = _not_supported("mount")
-    host = _not_supported("host")
-    add_route = _not_supported("add_route")
-    add_websocket_route = _not_supported("add_websocket_route")
-    route = _not_supported("route")
-    websocket_route = _not_supported("websocket_route")
-    add_event_handler = _not_supported("add_event_handler")
-    on_event = _not_supported("on_event")
+    mount = not_supported("mount")
+    host = not_supported("host")
+    add_route = not_supported("add_route")
+    add_websocket_route = not_supported("add_websocket_route")
+    route = not_supported("route")
+    websocket_route = not_supported("websocket_route")
+    add_event_handler = not_supported("add_event_handler")
+    on_event = not_supported("on_event")

--- a/xpresso/routing/router.py
+++ b/xpresso/routing/router.py
@@ -1,9 +1,9 @@
 import typing
 
-from starlette.applications import Starlette
+import starlette.middleware
 from starlette.routing import BaseRoute
 from starlette.routing import Router as StarletteRouter
-from starlette.types import ASGIApp
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from xpresso.dependencies.models import Dependant
 from xpresso.responses import Responses
@@ -21,29 +21,48 @@ def _not_supported(method: str) -> typing.Callable[..., typing.Any]:
 
 class Router(StarletteRouter):
     routes: typing.List[BaseRoute]
+    _app: ASGIApp
 
     def __init__(
         self,
         routes: typing.Sequence[BaseRoute],
         *,
+        middleware: typing.Optional[
+            typing.Sequence[starlette.middleware.Middleware]
+        ] = None,
         redirect_slashes: bool = True,
         default: typing.Optional[ASGIApp] = None,
-        lifespan: typing.Optional[
-            typing.Callable[[Starlette], typing.AsyncContextManager[None]]
-        ] = None,
         dependencies: typing.Optional[typing.List[Dependant]] = None,
         tags: typing.Optional[typing.List[str]] = None,
         responses: typing.Optional[Responses] = None,
+        include_in_schema: bool = True,
     ) -> None:
         super().__init__(  # type: ignore
             routes=list(routes),
             redirect_slashes=redirect_slashes,
             default=default,  # type: ignore
-            lifespan=lifespan,  # type: ignore
+            lifespan=None,  # type: ignore
         )
         self.dependencies = list(dependencies or [])
         self.tags = list(tags or [])
         self.responses = dict(responses or {})
+        self.include_in_schema = include_in_schema
+        self._app = super().__call__  # type: ignore[assignment,misc]
+        if middleware is not None:
+            for cls, options in reversed(middleware):  # type: ignore  # for Pylance
+                self._app = cls(app=self._app, **options)  # type: ignore[assignment,misc]
+
+    async def __call__(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+
+        if "router" not in scope:
+            scope["router"] = self
+
+        await self._app(scope, receive, send)  # type: ignore[arg-type,call-arg,misc]
 
     mount = _not_supported("mount")
     host = _not_supported("host")

--- a/xpresso/routing/websockets.py
+++ b/xpresso/routing/websockets.py
@@ -54,6 +54,8 @@ class _WebSocketRoute:
 
 
 class WebSocketRoute(starlette.routing.WebSocketRoute):
+    path: str
+
     def __init__(
         self,
         path: str,


### PR DESCRIPTION
Closes #32 

This is a middle road of where we are now and #32: `App` is not longer based on `Starlette`, but `Router` still inherits from Starlette's `Router` and adds middleware on top of it