### PR TITLE
BREAKING_CHANGE: rename Dependant -> Depends

### DIFF
--- a/benchmarks/xpresso_app.py
+++ b/benchmarks/xpresso_app.py
@@ -10,11 +10,11 @@ from benchmarks.constants import DAG_SHAPE, DELAY, NO_DELAY, ROUTING_PATHS
 from benchmarks.utils import generate_dag
 
 def make_depends(type_: str, provider: str) -> str:
-    return f"Annotated[{type_}, Dependant({provider})]"
+    return f"Annotated[{type_}, Depends({provider})]"
 
 
 glbls: Dict[str, Any] = {
-    "Dependant": Depends,
+    "Depends": Depends,
     "Annotated": Annotated,
 }
 

--- a/benchmarks/xpresso_app.py
+++ b/benchmarks/xpresso_app.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, Mapping, Union, List
 
 from starlette.routing import BaseRoute, Route
 
-from xpresso import App, Dependant, Operation, Path, Request, Response, Router
+from xpresso import App, Depends, Operation, Path, Request, Response, Router
 from xpresso.routing.mount import Mount
 from xpresso.typing import Annotated
 
@@ -14,7 +14,7 @@ def make_depends(type_: str, provider: str) -> str:
 
 
 glbls: Dict[str, Any] = {
-    "Dependant": Dependant,
+    "Dependant": Depends,
     "Annotated": Annotated,
 }
 
@@ -31,7 +31,7 @@ print("/fast_deps dag size: ", dag_size)
 
 
 def fast_dependencies(
-    _: Annotated[int, Dependant(dep_without_delays)]
+    _: Annotated[int, Depends(dep_without_delays)]
 ) -> Response:
     """An endpoint with dependencies that execute instantly"""
     return Response()
@@ -44,7 +44,7 @@ print("/slow_deps dag size: ", dag_size)
 
 
 def slow_dependencies(
-    _: Annotated[int, Dependant(dep_with_delays)]
+    _: Annotated[int, Depends(dep_with_delays)]
 ) -> Response:
     """An endpoint with dependencies that simulate IO"""
     return Response()

--- a/docs/advanced/dependencies/caching.md
+++ b/docs/advanced/dependencies/caching.md
@@ -3,7 +3,7 @@
 Xpresso has a dependency caching system.
 This allows re-using of already computed dependencies within a request response cycle.
 This is also what enables Xpresso to persist `"app"` scoped dependencies across requests (see [Scopes]).
-By default, all dependencies are cached within their execution scope, but this can be disabled on a per-dependency basis with the `use_cache` argument to `Dependant`.
+By default, all dependencies are cached within their execution scope, but this can be disabled on a per-dependency basis with the `use_cache` argument to `Depends`.
 
 First we are going to declare a placeholder dependency with no sub-dependencies.
 We are just going to compare instances, so there's nothing else needed in this dependency.

--- a/docs/advanced/dependencies/performance.md
+++ b/docs/advanced/dependencies/performance.md
@@ -14,7 +14,7 @@ This means that **sync dependencies will block the event loop**: a single sync d
 
 Fortunately, this is not a problem for many sync dependencies: if you are just loading a config from environment variables or otherwise not doing IO, your sync dependency won't "block" the event loop and your app will run fine.
 When you really need to start worrying about things is if you are doing database IO with a synchronous database client or something like that.
-For these cases, Xpresso provides a `sync_to_thread` argument to `Dependant` as well as `Operation`.
+For these cases, Xpresso provides a `sync_to_thread` argument to `Depends` as well as `Operation`.
 This will move execution of this dependency or endpoint function into a thread so that it can do IO concurrently and not block your application.
 For example, let's make a sync endpoint and sync dependencies that call `time.sleep()` to simulate some sort of blocking IO:
 

--- a/docs/tutorial/dependencies/README.md
+++ b/docs/tutorial/dependencies/README.md
@@ -87,8 +87,8 @@ You can declare it in the endpoint function's signature, but often it is conveni
 ```
 
 !!! tip "Tip"
-    For simple cases like this, you can even use a lambda function: `Dependant(lambda: httpx.AsyncClient(...))`
-    Just be concious of legibility!
+    For simple cases like this, you can even use a lambda function: `Depends(lambda: httpx.AsyncClient(...))`
+    Just be conscious of legibility!
 
 Since we are now specifying the `base_url` when we construct the `httpx.AsyncClient`, we can just use `"/get"` as the URL in our endpoint function:
 

--- a/docs_src/advanced/dependencies/tutorial_001.py
+++ b/docs_src/advanced/dependencies/tutorial_001.py
@@ -1,6 +1,6 @@
 import time
 
-from xpresso import App, Dependant, Operation, Path
+from xpresso import App, Depends, Operation, Path
 
 
 def slow_dependency() -> None:
@@ -19,7 +19,7 @@ app = App(
                 endpoint=slow_endpoint,
                 sync_to_thread=True,
                 dependencies=[
-                    Dependant(slow_dependency, sync_to_thread=True)
+                    Depends(slow_dependency, sync_to_thread=True)
                 ],
             ),
         )

--- a/docs_src/advanced/dependencies/tutorial_002.py
+++ b/docs_src/advanced/dependencies/tutorial_002.py
@@ -2,7 +2,7 @@ import time
 
 import anyio
 
-from xpresso import App, Dependant, Operation, Path
+from xpresso import App, Depends, Operation, Path
 
 
 def slow_dependency_1() -> None:
@@ -24,8 +24,8 @@ app = App(
             get=Operation(
                 endpoint=endpoint,
                 dependencies=[
-                    Dependant(slow_dependency_1, sync_to_thread=True),
-                    Dependant(slow_dependency_2),
+                    Depends(slow_dependency_1, sync_to_thread=True),
+                    Depends(slow_dependency_2),
                 ],
                 execute_dependencies_concurrently=True,
             ),

--- a/docs_src/advanced/dependencies/tutorial_003.py
+++ b/docs_src/advanced/dependencies/tutorial_003.py
@@ -1,4 +1,4 @@
-from xpresso import App, Dependant, Path
+from xpresso import App, Depends, Path
 from xpresso.typing import Annotated
 
 
@@ -15,11 +15,9 @@ def dependency_2(shared: SharedDependency) -> SharedDependency:
 
 
 async def endpoint(
-    shared1: Annotated[SharedDependency, Dependant(dependency_1)],
-    shared2: Annotated[SharedDependency, Dependant(dependency_1)],
-    shared3: Annotated[
-        SharedDependency, Dependant(SharedDependency, use_cache=False)
-    ],
+    shared1: Annotated[SharedDependency, Depends(dependency_1)],
+    shared2: Annotated[SharedDependency, Depends(dependency_1)],
+    shared3: Annotated[SharedDependency, Depends(use_cache=False)],
 ) -> None:
     assert shared1 is shared2
     assert shared1 is not shared3

--- a/docs_src/advanced/dependencies/tutorial_004.py
+++ b/docs_src/advanced/dependencies/tutorial_004.py
@@ -2,14 +2,13 @@ from typing import Generator, List
 
 from xpresso import (
     App,
-    Dependant,
+    Depends,
     FromPath,
     HTTPException,
     Path,
     Request,
 )
 from xpresso.responses import get_response
-from xpresso.typing import Annotated
 
 
 class StatusCodeLogFile(List[int]):
@@ -18,7 +17,7 @@ class StatusCodeLogFile(List[int]):
 
 def log_response_status_code(
     request: Request,
-    log: Annotated[StatusCodeLogFile, Dependant(scope="connection")],
+    log: StatusCodeLogFile,
 ) -> Generator[None, None, None]:
     try:
         yield
@@ -45,9 +44,7 @@ app = App(
             path="/items/{item_name}",
             get=read_items,
             dependencies=[
-                Dependant(
-                    log_response_status_code, scope="connection"
-                )
+                Depends(log_response_status_code, scope="connection")
             ],
         ),
     ]

--- a/docs_src/advanced/dependencies/tutorial_005.py
+++ b/docs_src/advanced/dependencies/tutorial_005.py
@@ -3,7 +3,7 @@ from uuid import UUID, uuid4
 
 from xpresso import (
     App,
-    Dependant,
+    Depends,
     FromPath,
     HTTPException,
     Path,
@@ -44,7 +44,7 @@ app = App(
         Path(
             path="/items/{item_name}",
             get=read_items,
-            dependencies=[Dependant(trace, scope="endpoint")],
+            dependencies=[Depends(trace, scope="endpoint")],
         ),
     ]
 )

--- a/docs_src/advanced/websockets.py
+++ b/docs_src/advanced/websockets.py
@@ -1,6 +1,6 @@
 from xpresso import (
     App,
-    Dependant,
+    Depends,
     FromHeader,
     WebSocket,
     WebSocketRoute,
@@ -31,7 +31,7 @@ app = App(
         WebSocketRoute(
             path="/ws",
             endpoint=websocket_endpoint,
-            dependencies=[Dependant(enforce_header_pattern)],
+            dependencies=[Depends(enforce_header_pattern)],
         ),
     ]
 )

--- a/docs_src/tutorial/dependencies/tutorial_002.py
+++ b/docs_src/tutorial/dependencies/tutorial_002.py
@@ -1,6 +1,6 @@
 import httpx
 
-from xpresso import App, Dependant, Path
+from xpresso import App, Depends, Path
 from xpresso.typing import Annotated
 
 
@@ -8,7 +8,7 @@ def get_client() -> httpx.AsyncClient:
     return httpx.AsyncClient(base_url="https://httpbin.org")
 
 
-HttpbinClient = Annotated[httpx.AsyncClient, Dependant(get_client)]
+HttpbinClient = Annotated[httpx.AsyncClient, Depends(get_client)]
 
 
 async def echo_url(client: HttpbinClient) -> str:

--- a/docs_src/tutorial/dependencies/tutorial_003.py
+++ b/docs_src/tutorial/dependencies/tutorial_003.py
@@ -1,7 +1,7 @@
 import httpx
 from pydantic import BaseSettings
 
-from xpresso import App, Dependant, Path
+from xpresso import App, Depends, Path
 from xpresso.typing import Annotated
 
 
@@ -13,7 +13,7 @@ class HttpBinConfigModel(BaseSettings):
 
 
 HttpBinConfig = Annotated[
-    HttpBinConfigModel, Dependant(lambda: HttpBinConfigModel())
+    HttpBinConfigModel, Depends(lambda: HttpBinConfigModel())
 ]
 
 
@@ -21,7 +21,7 @@ def get_client(config: HttpBinConfig) -> httpx.AsyncClient:
     return httpx.AsyncClient(base_url=config.url)
 
 
-HttpbinClient = Annotated[httpx.AsyncClient, Dependant(get_client)]
+HttpbinClient = Annotated[httpx.AsyncClient, Depends(get_client)]
 
 
 async def echo_url(client: HttpbinClient) -> str:

--- a/docs_src/tutorial/dependencies/tutorial_004.py
+++ b/docs_src/tutorial/dependencies/tutorial_004.py
@@ -3,7 +3,7 @@ from typing import AsyncGenerator
 import httpx
 from pydantic import BaseSettings
 
-from xpresso import App, Dependant, Path
+from xpresso import App, Depends, Path
 from xpresso.typing import Annotated
 
 
@@ -15,7 +15,7 @@ class HttpBinConfigModel(BaseSettings):
 
 
 HttpBinConfig = Annotated[
-    HttpBinConfigModel, Dependant(lambda: HttpBinConfigModel())
+    HttpBinConfigModel, Depends(lambda: HttpBinConfigModel())
 ]
 
 
@@ -26,7 +26,7 @@ async def get_client(
         yield client
 
 
-HttpbinClient = Annotated[httpx.AsyncClient, Dependant(get_client)]
+HttpbinClient = Annotated[httpx.AsyncClient, Depends(get_client)]
 
 
 async def echo_url(client: HttpbinClient) -> str:

--- a/docs_src/tutorial/dependencies/tutorial_006.py
+++ b/docs_src/tutorial/dependencies/tutorial_006.py
@@ -3,7 +3,7 @@ from typing import AsyncGenerator
 import httpx
 from pydantic import BaseSettings
 
-from xpresso import App, Dependant, Path
+from xpresso import App, Depends, Path
 from xpresso.typing import Annotated
 
 
@@ -16,7 +16,7 @@ class HttpBinConfigModel(BaseSettings):
 
 HttpBinConfig = Annotated[
     HttpBinConfigModel,
-    Dependant(lambda: HttpBinConfigModel(), scope="app"),
+    Depends(lambda: HttpBinConfigModel(), scope="app"),
 ]
 
 
@@ -28,7 +28,7 @@ async def get_client(
 
 
 HttpbinClient = Annotated[
-    httpx.AsyncClient, Dependant(get_client, scope="app")
+    httpx.AsyncClient, Depends(get_client, scope="app")
 ]
 
 

--- a/docs_src/tutorial/dependencies/tutorial_007.py
+++ b/docs_src/tutorial/dependencies/tutorial_007.py
@@ -2,7 +2,7 @@ from typing import Callable, FrozenSet, Optional
 
 from xpresso import (
     App,
-    Dependant,
+    Depends,
     FromPath,
     FromQuery,
     HTTPException,
@@ -41,12 +41,10 @@ app = App(
             get=get_item,  # no extra roles required
             delete=Operation(
                 endpoint=delete_item,
-                dependencies=[
-                    Dependant(require_roles("items-admin"))
-                ],
+                dependencies=[Depends(require_roles("items-admin"))],
             ),
-            dependencies=[Dependant(require_roles("items-user"))],
+            dependencies=[Depends(require_roles("items-user"))],
         )
     ],
-    dependencies=[Dependant(require_roles("user"))],
+    dependencies=[Depends(require_roles("user"))],
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xpresso"
-version = "0.14.4"
+version = "0.15.0"
 description = "A developer centric, performant Python web framework"
 authors = ["Adrian Garcia Badaracco <adrian@adriangb.com>"]
 readme = "README.md"

--- a/tests/test_dependency_injection.py
+++ b/tests/test_dependency_injection.py
@@ -6,7 +6,7 @@ from di import BaseContainer
 from starlette.responses import Response
 from starlette.testclient import TestClient
 
-from xpresso import App, Dependant, Operation, Path
+from xpresso import App, Depends, Operation, Path
 from xpresso.typing import Annotated
 
 
@@ -16,21 +16,19 @@ def test_router_route_dependencies() -> None:
     class TrackingDep:
         o: object = None
 
-        def __call__(self, o: Annotated[object, Dependant(scope="app")]) -> None:
+        def __call__(self, o: Annotated[object, Depends(scope="app")]) -> None:
             self.o = o
 
     router_dep = TrackingDep()
     route_dep = TrackingDep()
     endpoint_dep = TrackingDep()
 
-    async def endpoint(v: Annotated[None, Dependant(endpoint_dep)]) -> Response:
+    async def endpoint(v: Annotated[None, Depends(endpoint_dep)]) -> Response:
         return Response()
 
     app = App(
-        routes=[
-            Path("/", get=Operation(endpoint, dependencies=[Dependant(route_dep)]))
-        ],
-        dependencies=[Dependant(router_dep)],
+        routes=[Path("/", get=Operation(endpoint, dependencies=[Depends(route_dep)]))],
+        dependencies=[Depends(router_dep)],
     )
 
     with TestClient(app=app) as client:
@@ -44,7 +42,7 @@ def test_lifespan_dependencies() -> None:
     class Test:
         foo: str = "foo"
 
-    TestDep = Annotated[Test, Dependant(scope="app")]
+    TestDep = Annotated[Test, Depends(scope="app")]
 
     @asynccontextmanager
     async def lifespan(t: TestDep) -> AsyncIterator[None]:

--- a/tests/test_docs/advanced/dependencies/test_tutorial_004.py
+++ b/tests/test_docs/advanced/dependencies/test_tutorial_004.py
@@ -1,12 +1,12 @@
 from docs_src.advanced.dependencies.tutorial_004 import StatusCodeLogFile, app
-from xpresso import Dependant
+from xpresso import Depends
 from xpresso.testclient import TestClient
 
 
 def test_read_items_logging() -> None:
     log = StatusCodeLogFile()
     with app.container.register_by_type(
-        Dependant(lambda: log, scope="connection"), StatusCodeLogFile
+        Depends(lambda: log, scope="connection"), StatusCodeLogFile
     ):
         client = TestClient(app)
 

--- a/tests/test_docs/tutorial/dependencies/test_tutorial_001.py
+++ b/tests/test_docs/tutorial/dependencies/test_tutorial_001.py
@@ -1,7 +1,7 @@
 import httpx
 
 from docs_src.tutorial.dependencies.tutorial_001 import app
-from xpresso import Dependant
+from xpresso import Depends
 from xpresso.testclient import TestClient
 
 
@@ -11,7 +11,7 @@ def test_client_injection():
         return httpx.Response(200, json={"url": "https://httpbin.org/get"})
 
     with app.container.register_by_type(
-        Dependant(lambda: httpx.AsyncClient(transport=httpx.MockTransport(handler))),
+        Depends(lambda: httpx.AsyncClient(transport=httpx.MockTransport(handler))),
         httpx.AsyncClient,
     ):
         client = TestClient(app)

--- a/tests/test_docs/tutorial/dependencies/test_tutorial_002.py
+++ b/tests/test_docs/tutorial/dependencies/test_tutorial_002.py
@@ -1,7 +1,7 @@
 import httpx
 
 from docs_src.tutorial.dependencies.tutorial_002 import app
-from xpresso import Dependant
+from xpresso import Depends
 from xpresso.testclient import TestClient
 
 
@@ -11,7 +11,7 @@ def test_client_injection():
         return httpx.Response(200, json={"url": "https://httpbin.org/get"})
 
     with app.container.register_by_type(
-        Dependant(
+        Depends(
             lambda: httpx.AsyncClient(
                 transport=httpx.MockTransport(handler), base_url="https://httpbin.org"
             )

--- a/tests/test_docs/tutorial/dependencies/test_tutorial_003.py
+++ b/tests/test_docs/tutorial/dependencies/test_tutorial_003.py
@@ -3,7 +3,7 @@ from contextlib import ExitStack
 import httpx
 
 from docs_src.tutorial.dependencies.tutorial_003 import HttpBinConfigModel, app
-from xpresso import Dependant
+from xpresso import Depends
 from xpresso.testclient import TestClient
 
 
@@ -27,13 +27,13 @@ def test_client_config_injection():
     with ExitStack() as stack:
         stack.enter_context(
             app.container.register_by_type(
-                Dependant(lambda: HttpBinConfigModel(url=test_url)),
+                Depends(lambda: HttpBinConfigModel(url=test_url)),
                 HttpBinConfigModel,
             )
         )
         stack.enter_context(
             app.container.register_by_type(
-                Dependant(get_client),
+                Depends(get_client),
                 httpx.AsyncClient,
             )
         )

--- a/tests/test_docs/tutorial/dependencies/test_tutorial_004.py
+++ b/tests/test_docs/tutorial/dependencies/test_tutorial_004.py
@@ -1,7 +1,7 @@
 import httpx
 
 from docs_src.tutorial.dependencies.tutorial_004 import app
-from xpresso import Dependant
+from xpresso import Depends
 from xpresso.testclient import TestClient
 
 
@@ -11,7 +11,7 @@ def test_client_injection():
         return httpx.Response(200, json={"url": "https://httpbin.org/get"})
 
     with app.container.register_by_type(
-        Dependant(
+        Depends(
             lambda: httpx.AsyncClient(
                 transport=httpx.MockTransport(handler), base_url="https://httpbin.org"
             )

--- a/tests/test_docs/tutorial/dependencies/test_tutorial_006.py
+++ b/tests/test_docs/tutorial/dependencies/test_tutorial_006.py
@@ -1,7 +1,7 @@
 import httpx
 
 from docs_src.tutorial.dependencies.tutorial_006 import app
-from xpresso import Dependant
+from xpresso import Depends
 from xpresso.testclient import TestClient
 
 
@@ -11,7 +11,7 @@ def test_client_injection():
         return httpx.Response(200, json={"url": "https://httpbin.org/get"})
 
     with app.container.register_by_type(
-        Dependant(
+        Depends(
             lambda: httpx.AsyncClient(
                 transport=httpx.MockTransport(handler), base_url="https://httpbin.org"
             )

--- a/tests/test_lifespans.py
+++ b/tests/test_lifespans.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, List
 
-from xpresso import App, Dependant, Router
+from xpresso import App, Depends, Router
 from xpresso.routing.mount import Mount
 from xpresso.testclient import TestClient
 
@@ -18,9 +18,7 @@ def test_lifespan_mounted_app() -> None:
     counter = Counter()
 
     inner_app = App(lifespan=lifespan)
-    inner_app.container.register_by_type(
-        Dependant(lambda: counter, scope="app"), Counter
-    )
+    inner_app.container.register_by_type(Depends(lambda: counter, scope="app"), Counter)
 
     app = App(
         routes=[
@@ -30,7 +28,7 @@ def test_lifespan_mounted_app() -> None:
         lifespan=lifespan,
     )
 
-    app.container.register_by_type(Dependant(lambda: counter, scope="app"), Counter)
+    app.container.register_by_type(Depends(lambda: counter, scope="app"), Counter)
 
     with TestClient(app):
         pass

--- a/tests/test_responses/test_response_proxy.py
+++ b/tests/test_responses/test_response_proxy.py
@@ -13,7 +13,7 @@ if sys.version_info < (3, 9):
 else:
     from typing import Annotated
 
-from xpresso import App, Dependant, Path
+from xpresso import App, Depends, Path
 from xpresso.exceptions import XpressoError
 from xpresso.responses import get_response, set_response
 
@@ -35,7 +35,7 @@ def test_get_response(scope: typing.Any) -> None:
         response.status_code = 405
 
     async def endpoint(
-        dep: Annotated[None, Dependant(dependency, scope=scope)]
+        dep: Annotated[None, Depends(dependency, scope=scope)]
     ) -> Response:
         return Response(status_code=404)
 
@@ -57,7 +57,7 @@ def test_get_response_connection_scope() -> None:
         response.status_code = 404
 
     async def endpoint(
-        dep: Annotated[None, Dependant(dependency, scope="connection")]
+        dep: Annotated[None, Depends(dependency, scope="connection")]
     ) -> Response:
         return Response(status_code=405)
 
@@ -83,7 +83,7 @@ def test_set_response() -> None:
             Path(
                 "/",
                 get=endpoint,
-                dependencies=[Dependant(dependency, scope="endpoint")],
+                dependencies=[Depends(dependency, scope="endpoint")],
             )
         ]
     )
@@ -107,7 +107,7 @@ def test_set_response_operation_scope() -> None:
             Path(
                 "/",
                 get=endpoint,
-                dependencies=[Dependant(dependency, scope="connection")],
+                dependencies=[Depends(dependency, scope="connection")],
             )
         ]
     )

--- a/tests/test_routing/test_mounts.py
+++ b/tests/test_routing/test_mounts.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 
 from di import BaseContainer
 
-from xpresso import App, Dependant, FromPath, Path
+from xpresso import App, Depends, FromPath, Path
 from xpresso.routing.mount import Mount
 from xpresso.testclient import TestClient
 
@@ -283,7 +283,7 @@ def test_mounted_xpresso_app_dependencies_isolated_containers() -> None:
     )
 
     app.container.register_by_type(
-        Dependant(lambda: Thing("injected")),
+        Depends(lambda: Thing("injected")),
         Thing,
     )
 
@@ -311,7 +311,7 @@ def test_mounted_xpresso_app_dependencies_shared_containers() -> None:
 
     container = BaseContainer(scopes=("app", "connection", "endpoint"))
     container.register_by_type(
-        Dependant(lambda: Thing("injected")),
+        Depends(lambda: Thing("injected")),
         Thing,
     )
 

--- a/tests/test_security/test_security_api_key_cookie.py
+++ b/tests/test_security/test_security_api_key_cookie.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Generator
 import pytest
 from pydantic import BaseModel
 
-from xpresso import App, Dependant, Path, Security
+from xpresso import App, Depends, Path, Security
 from xpresso.security import APIKeyCookie
 from xpresso.testclient import TestClient
 from xpresso.typing import Annotated
@@ -20,7 +20,7 @@ def get_current_user(oauth_header: Annotated[str, Security(api_key)]):
     return user
 
 
-def read_current_user(current_user: Annotated[User, Dependant(get_current_user)]):
+def read_current_user(current_user: Annotated[User, Depends(get_current_user)]):
     return current_user
 
 

--- a/tests/test_security/test_security_api_key_cookie_description.py
+++ b/tests/test_security/test_security_api_key_cookie_description.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Generator
 import pytest
 from pydantic import BaseModel
 
-from xpresso import App, Dependant, Path, Security
+from xpresso import App, Depends, Path, Security
 from xpresso.security import APIKeyCookie
 from xpresso.testclient import TestClient
 from xpresso.typing import Annotated
@@ -20,7 +20,7 @@ def get_current_user(oauth_header: Annotated[str, Security(api_key)]):
     return user
 
 
-def read_current_user(current_user: Annotated[User, Dependant(get_current_user)]):
+def read_current_user(current_user: Annotated[User, Depends(get_current_user)]):
     return current_user
 
 

--- a/tests/test_security/test_security_api_key_cookie_optional.py
+++ b/tests/test_security/test_security_api_key_cookie_optional.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Generator, Optional
 import pytest
 from pydantic import BaseModel
 
-from xpresso import App, Dependant, Path, Security
+from xpresso import App, Depends, Path, Security
 from xpresso.security import APIKeyCookie
 from xpresso.testclient import TestClient
 from xpresso.typing import Annotated
@@ -23,7 +23,7 @@ def get_current_user(oauth_header: Annotated[Optional[str], Security(api_key)]):
 
 
 def read_current_user(
-    current_user: Annotated[Optional[User], Dependant(get_current_user)]
+    current_user: Annotated[Optional[User], Depends(get_current_user)]
 ):
     if current_user is None:
         return {"msg": "Create an account first"}

--- a/tests/test_security/test_security_api_key_header.py
+++ b/tests/test_security/test_security_api_key_header.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Generator
 import pytest
 from pydantic import BaseModel
 
-from xpresso import App, Dependant, Path, Security
+from xpresso import App, Depends, Path, Security
 from xpresso.security import APIKeyHeader
 from xpresso.testclient import TestClient
 from xpresso.typing import Annotated
@@ -20,7 +20,7 @@ def get_current_user(oauth_header: Annotated[str, Security(api_key)]):
     return user
 
 
-def read_current_user(current_user: Annotated[User, Dependant(get_current_user)]):
+def read_current_user(current_user: Annotated[User, Depends(get_current_user)]):
     return current_user
 
 

--- a/tests/test_security/test_security_api_key_header_deferred.py
+++ b/tests/test_security/test_security_api_key_header_deferred.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Generator
 import pytest
 from pydantic import BaseModel
 
-from xpresso import App, Dependant, Path, Security
+from xpresso import App, Depends, Path, Security
 from xpresso.security import APIKeyHeader
 from xpresso.testclient import TestClient
 from xpresso.typing import Annotated
@@ -14,7 +14,7 @@ def get_name() -> str:
 
 
 class LazyAPIKeyHeader(APIKeyHeader):
-    def __init__(self, name: Annotated[str, Dependant(get_name, scope="app")]) -> None:
+    def __init__(self, name: Annotated[str, Depends(get_name, scope="app")]) -> None:
         super().__init__(name=name)
 
 
@@ -27,7 +27,7 @@ def get_current_user(oauth_header: Annotated[str, Security(LazyAPIKeyHeader)]):
     return user
 
 
-def read_current_user(current_user: Annotated[User, Dependant(get_current_user)]):
+def read_current_user(current_user: Annotated[User, Depends(get_current_user)]):
     return current_user
 
 

--- a/tests/test_security/test_security_api_key_header_description.py
+++ b/tests/test_security/test_security_api_key_header_description.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Generator
 import pytest
 from pydantic import BaseModel
 
-from xpresso import App, Dependant, Path, Security
+from xpresso import App, Depends, Path, Security
 from xpresso.security import APIKeyHeader
 from xpresso.testclient import TestClient
 from xpresso.typing import Annotated
@@ -20,7 +20,7 @@ def get_current_user(oauth_header: Annotated[str, Security(api_key)]):
     return user
 
 
-def read_current_user(current_user: Annotated[User, Dependant(get_current_user)]):
+def read_current_user(current_user: Annotated[User, Depends(get_current_user)]):
     return current_user
 
 

--- a/tests/test_security/test_security_api_key_header_optional.py
+++ b/tests/test_security/test_security_api_key_header_optional.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Generator, Optional
 import pytest
 from pydantic import BaseModel
 
-from xpresso import App, Dependant, Path, Security
+from xpresso import App, Depends, Path, Security
 from xpresso.security import APIKeyHeader
 from xpresso.testclient import TestClient
 from xpresso.typing import Annotated
@@ -23,7 +23,7 @@ def get_current_user(oauth_header: Annotated[Optional[str], Security(api_key)]):
 
 
 def read_current_user(
-    current_user: Annotated[Optional[User], Dependant(get_current_user)]
+    current_user: Annotated[Optional[User], Depends(get_current_user)]
 ):
     if current_user is None:
         return {"msg": "Create an account first"}

--- a/tests/test_security/test_security_api_key_query.py
+++ b/tests/test_security/test_security_api_key_query.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Generator
 import pytest
 from pydantic import BaseModel
 
-from xpresso import App, Dependant, Path, Security
+from xpresso import App, Depends, Path, Security
 from xpresso.security import APIKeyQuery
 from xpresso.testclient import TestClient
 from xpresso.typing import Annotated
@@ -20,7 +20,7 @@ def get_current_user(oauth_header: Annotated[str, Security(api_key)]):
     return user
 
 
-def read_current_user(current_user: Annotated[User, Dependant(get_current_user)]):
+def read_current_user(current_user: Annotated[User, Depends(get_current_user)]):
     return current_user
 
 

--- a/tests/test_security/test_security_api_key_query_description.py
+++ b/tests/test_security/test_security_api_key_query_description.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Generator
 import pytest
 from pydantic import BaseModel
 
-from xpresso import App, Dependant, Path, Security
+from xpresso import App, Depends, Path, Security
 from xpresso.security import APIKeyQuery
 from xpresso.testclient import TestClient
 from xpresso.typing import Annotated
@@ -20,7 +20,7 @@ def get_current_user(oauth_header: Annotated[str, Security(api_key)]):
     return user
 
 
-def read_current_user(current_user: Annotated[User, Dependant(get_current_user)]):
+def read_current_user(current_user: Annotated[User, Depends(get_current_user)]):
     return current_user
 
 

--- a/tests/test_security/test_security_api_key_query_optional.py
+++ b/tests/test_security/test_security_api_key_query_optional.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Generator, Optional
 import pytest
 from pydantic import BaseModel
 
-from xpresso import App, Dependant, Path, Security
+from xpresso import App, Depends, Path, Security
 from xpresso.security import APIKeyQuery
 from xpresso.testclient import TestClient
 from xpresso.typing import Annotated
@@ -23,7 +23,7 @@ def get_current_user(oauth_header: Annotated[Optional[str], Security(api_key)]):
 
 
 def read_current_user(
-    current_user: Annotated[Optional[User], Dependant(get_current_user)]
+    current_user: Annotated[Optional[User], Depends(get_current_user)]
 ):
     if current_user is None:
         return {"msg": "Create an account first"}

--- a/tests/test_security/test_security_oauth2.py
+++ b/tests/test_security/test_security_oauth2.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Generator
 import pytest
 from pydantic import BaseModel
 
-from xpresso import App, Dependant, FromFormData, Path, Security
+from xpresso import App, Depends, FromFormData, Path, Security
 from xpresso.security import OAuth2, OAuth2PasswordRequestFormStrict
 from xpresso.testclient import TestClient
 from xpresso.typing import Annotated
@@ -34,7 +34,7 @@ def login(form_data: "FromFormData[OAuth2PasswordRequestFormStrict]"):
 
 
 # Here we use string annotations to test them
-def read_current_user(current_user: "Annotated[User, Dependant(get_current_user)]"):
+def read_current_user(current_user: "Annotated[User, Depends(get_current_user)]"):
     return current_user
 
 

--- a/tests/test_security/test_security_oauth2_optional.py
+++ b/tests/test_security/test_security_oauth2_optional.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Generator, Optional
 import pytest
 from pydantic import BaseModel
 
-from xpresso import App, Dependant, FromFormData, Path, Security
+from xpresso import App, Depends, FromFormData, Path, Security
 from xpresso.security import OAuth2, OAuth2PasswordRequestFormStrict
 from xpresso.testclient import TestClient
 from xpresso.typing import Annotated
@@ -34,7 +34,7 @@ def login(form_data: FromFormData[OAuth2PasswordRequestFormStrict]):
     return form_data
 
 
-def read_users_me(current_user: Annotated[Optional[User], Dependant(get_current_user)]):
+def read_users_me(current_user: Annotated[Optional[User], Depends(get_current_user)]):
     if current_user is None:
         return {"msg": "Create an account first"}
     return current_user

--- a/tests/test_security/test_security_oauth2_optional_description.py
+++ b/tests/test_security/test_security_oauth2_optional_description.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Generator, Optional
 import pytest
 from pydantic import BaseModel
 
-from xpresso import App, Dependant, FromFormData, Path, Security
+from xpresso import App, Depends, FromFormData, Path, Security
 from xpresso.security import OAuth2, OAuth2PasswordRequestFormStrict
 from xpresso.testclient import TestClient
 from xpresso.typing import Annotated
@@ -35,7 +35,7 @@ def login(form_data: FromFormData[OAuth2PasswordRequestFormStrict]):
     return form_data
 
 
-def read_users_me(current_user: Annotated[Optional[User], Dependant(get_current_user)]):
+def read_users_me(current_user: Annotated[Optional[User], Depends(get_current_user)]):
     if current_user is None:
         return {"msg": "Create an account first"}
     return current_user

--- a/tests/test_security/test_security_openid_connect.py
+++ b/tests/test_security/test_security_openid_connect.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Generator
 import pytest
 from pydantic import BaseModel
 
-from xpresso import App, Dependant, Path, Security
+from xpresso import App, Depends, Path, Security
 from xpresso.security import OpenIdConnect
 from xpresso.testclient import TestClient
 from xpresso.typing import Annotated
@@ -20,7 +20,7 @@ def get_current_user(oauth_header: Annotated[str, Security(oid)]):
     return user
 
 
-def read_current_user(current_user: Annotated[User, Dependant(get_current_user)]):
+def read_current_user(current_user: Annotated[User, Depends(get_current_user)]):
     return current_user
 
 

--- a/tests/test_security/test_security_openid_connect_description.py
+++ b/tests/test_security/test_security_openid_connect_description.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Generator
 import pytest
 from pydantic import BaseModel
 
-from xpresso import App, Dependant, Path, Security
+from xpresso import App, Depends, Path, Security
 from xpresso.security import OpenIdConnect
 from xpresso.testclient import TestClient
 from xpresso.typing import Annotated
@@ -22,7 +22,7 @@ def get_current_user(oauth_header: Annotated[str, Security(oid)]):
     return user
 
 
-def read_current_user(current_user: Annotated[User, Dependant(get_current_user)]):
+def read_current_user(current_user: Annotated[User, Depends(get_current_user)]):
     return current_user
 
 

--- a/tests/test_security/test_security_openid_connect_optional.py
+++ b/tests/test_security/test_security_openid_connect_optional.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Generator, Optional
 import pytest
 from pydantic import BaseModel
 
-from xpresso import App, Dependant, Path, Security
+from xpresso import App, Depends, Path, Security
 from xpresso.security import OpenIdConnect
 from xpresso.testclient import TestClient
 from xpresso.typing import Annotated
@@ -23,7 +23,7 @@ def get_current_user(oauth_header: Annotated[Optional[str], Security(oid)]):
 
 
 def read_current_user(
-    current_user: Annotated[Optional[User], Dependant(get_current_user)]
+    current_user: Annotated[Optional[User], Depends(get_current_user)]
 ):
     if current_user is None:
         return {"msg": "Create an account first"}

--- a/xpresso/__init__.py
+++ b/xpresso/__init__.py
@@ -29,7 +29,7 @@ from xpresso.binders._param_functions import (
     Security,
 )
 from xpresso.datastructures import UploadFile
-from xpresso.dependencies.models import Dependant
+from xpresso.dependencies.models import Depends
 from xpresso.exceptions import HTTPException
 from xpresso.requests import Request
 from xpresso.routing.operation import Operation
@@ -51,7 +51,7 @@ __all__ = (
     "Form",
     "File",
     "Multipart",
-    "Dependant",
+    "Depends",
     "App",
     "Router",
     "UploadFile",

--- a/xpresso/applications.py
+++ b/xpresso/applications.py
@@ -14,7 +14,7 @@ from starlette.routing import Route as StarletteRoute
 
 from xpresso._utils.asgi_scope_extension import XpressoASGIExtension
 from xpresso._utils.routing import visit_routes
-from xpresso.dependencies.models import Dependant
+from xpresso.dependencies.models import Depends
 from xpresso.dependencies.utils import register_framework_dependencies
 from xpresso.exception_handlers import (
     http_exception_handler,
@@ -100,7 +100,7 @@ class App:
         routes: typing.Optional[typing.Sequence[BaseRoute]] = None,
         *,
         container: typing.Optional[BaseContainer] = None,
-        dependencies: typing.Optional[typing.List[Dependant]] = None,
+        dependencies: typing.Optional[typing.List[Depends]] = None,
         debug: bool = False,
         middleware: typing.Optional[typing.Sequence[Middleware]] = None,
         exception_handlers: typing.Optional[ExceptionHandlers] = None,
@@ -130,16 +130,16 @@ class App:
             async with self.container.enter_scope("app") as container:
                 self.container = container
                 if lifespan is not None:
-                    dep = Dependant(
+                    dep = Depends(
                         _wrap_lifespan_as_async_generator(lifespan), scope="app"
                     )
                 else:
-                    dep = Dependant(lambda: None, scope="app")
+                    dep = Depends(lambda: None, scope="app")
                 solved = self.container.solve(
                     JoinedDependant(
                         dep,
                         siblings=[
-                            Dependant(lifespan, scope="app") for lifespan in lifespans
+                            Depends(lifespan, scope="app") for lifespan in lifespans
                         ],
                     )
                 )

--- a/xpresso/binders/_security/dependants.py
+++ b/xpresso/binders/_security/dependants.py
@@ -5,10 +5,10 @@ from typing import Optional, Sequence, Union
 from di.api.providers import DependencyProviderType
 
 from xpresso.binders.api import SecurityBase
-from xpresso.dependencies.models import Dependant
+from xpresso.dependencies.models import Depends
 
 
-class Security(Dependant):
+class Security(Depends):
     _dependency: Union[DependencyProviderType[SecurityBase], SecurityBase]
 
     def __init__(

--- a/xpresso/dependencies/models.py
+++ b/xpresso/dependencies/models.py
@@ -18,7 +18,7 @@ T = typing.TypeVar("T")
 Scope = Literal["app", "connection", "endpoint"]
 
 
-class Dependant(di.Dependant[typing.Any]):
+class Depends(di.Dependant[typing.Any]):
     __slots__ = ()
     scope: Scope
 
@@ -38,17 +38,17 @@ class Dependant(di.Dependant[typing.Any]):
             sync_to_thread=sync_to_thread,
         )
 
-    def initialize_sub_dependant(self, param: inspect.Parameter) -> Dependant:
+    def initialize_sub_dependant(self, param: inspect.Parameter) -> Depends:
         if param.default is param.empty:
             # try to auto-wire
-            return Dependant(
+            return Depends(
                 call=None,
                 scope=self.scope,
                 use_cache=self.use_cache,
             )
         # has a default parameter but we create a dependency anyway just for binds
         # but do not wire it to make autowiring less brittle and less magic
-        return Dependant(
+        return Depends(
             call=None,
             scope=self.scope,
             use_cache=self.use_cache,

--- a/xpresso/dependencies/utils.py
+++ b/xpresso/dependencies/utils.py
@@ -13,7 +13,7 @@ from starlette.background import BackgroundTasks
 from starlette.requests import HTTPConnection, Request
 from starlette.websockets import WebSocket
 
-from xpresso.dependencies.models import Dependant
+from xpresso.dependencies.models import Depends
 
 
 class App(Protocol):
@@ -26,15 +26,15 @@ def register_framework_dependencies(
     container: BaseContainer, app: App, app_type: typing.Type[App]
 ):
     container.register_by_type(
-        Dependant(Request, scope="connection", wire=False),
+        Depends(Request, scope="connection", wire=False),
         Request,
     )
     container.register_by_type(
-        Dependant(Request, scope="connection", wire=False),
+        Depends(Request, scope="connection", wire=False),
         Request,
     )
     container.register_by_type(
-        Dependant(
+        Depends(
             HTTPConnection,
             scope="connection",
             wire=False,
@@ -42,7 +42,7 @@ def register_framework_dependencies(
         HTTPConnection,
     )
     container.register_by_type(
-        Dependant(
+        Depends(
             WebSocket,
             scope="connection",
             wire=False,
@@ -50,7 +50,7 @@ def register_framework_dependencies(
         WebSocket,
     )
     container.register_by_type(
-        Dependant(
+        Depends(
             lambda: BackgroundTasks(),
             scope="connection",
             wire=False,
@@ -58,7 +58,7 @@ def register_framework_dependencies(
         BackgroundTasks,
     )
     container.register_by_type(
-        Dependant(
+        Depends(
             lambda: app.container,
             scope="app",
             wire=False,
@@ -67,7 +67,7 @@ def register_framework_dependencies(
         covariant=True,
     )
     container.register_by_type(
-        Dependant(
+        Depends(
             lambda: app,
             scope="app",
             wire=False,

--- a/xpresso/routing/operation.py
+++ b/xpresso/routing/operation.py
@@ -15,7 +15,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 import xpresso._utils.asgi_scope_extension as asgi_scope_extension
 import xpresso.binders.dependants as param_dependants
 import xpresso.openapi.models as openapi_models
-from xpresso.dependencies.models import Dependant
+from xpresso.dependencies.models import Depends
 from xpresso.encoders.api import Encoder
 from xpresso.encoders.json import JsonableEncoder
 from xpresso.responses import Responses
@@ -81,7 +81,7 @@ class Operation(BaseRoute):
         responses: typing.Optional[Responses] = None,
         # xpresso params
         name: typing.Optional[str] = None,
-        dependencies: typing.Optional[typing.Sequence[Dependant]] = None,
+        dependencies: typing.Optional[typing.Sequence[Depends]] = None,
         execute_dependencies_concurrently: bool = False,
         response_factory: typing.Callable[[typing.Any], Response] = JSONResponse,
         response_encoder: Encoder = JsonableEncoder(),
@@ -122,7 +122,7 @@ class Operation(BaseRoute):
     ) -> None:
         self.dependant = container.solve(
             JoinedDependant(
-                Dependant(
+                Depends(
                     self.endpoint, scope="endpoint", sync_to_thread=self.sync_to_thread
                 ),
                 siblings=[*dependencies, *(self.dependencies or ())],

--- a/xpresso/routing/pathitem.py
+++ b/xpresso/routing/pathitem.py
@@ -6,7 +6,7 @@ from di.api.providers import DependencyProvider as Endpoint
 
 import xpresso.binders.dependants as param_dependants
 import xpresso.openapi.models as openapi_models
-from xpresso.dependencies.models import Dependant
+from xpresso.dependencies.models import Depends
 from xpresso.responses import Responses
 from xpresso.routing.operation import Operation
 
@@ -45,7 +45,7 @@ class Path(starlette.routing.Route):
         options: typing.Optional[typing.Union[Operation, Endpoint]] = None,
         trace: typing.Optional[typing.Union[Operation, Endpoint]] = None,
         redirect_slashes: bool = True,
-        dependencies: typing.Optional[typing.Sequence[Dependant]] = None,
+        dependencies: typing.Optional[typing.Sequence[Depends]] = None,
         # OpenAPI metadata
         include_in_schema: bool = True,
         name: typing.Optional[str] = None,

--- a/xpresso/routing/router.py
+++ b/xpresso/routing/router.py
@@ -11,7 +11,7 @@ from starlette.routing import BaseRoute
 from starlette.routing import Router as StarletteRouter
 from starlette.types import Receive, Scope, Send
 
-from xpresso.dependencies.models import Dependant
+from xpresso.dependencies.models import Depends
 from xpresso.responses import Responses
 
 
@@ -33,7 +33,7 @@ _MiddlewareIterator = typing.Iterable[
 class Router:
     routes: typing.Sequence[BaseRoute]
     lifespan: typing.Optional[typing.Callable[..., typing.AsyncContextManager[None]]]
-    dependencies: typing.Sequence[Dependant]
+    dependencies: typing.Sequence[Depends]
     tags: typing.Sequence[str]
     responses: Responses
     include_in_schema: bool
@@ -62,7 +62,7 @@ class Router:
         ] = None,
         redirect_slashes: bool = True,
         default: typing.Optional[_ASGIApp] = None,
-        dependencies: typing.Optional[typing.Sequence[Dependant]] = None,
+        dependencies: typing.Optional[typing.Sequence[Depends]] = None,
         tags: typing.Optional[typing.List[str]] = None,
         responses: typing.Optional[Responses] = None,
         include_in_schema: bool = True,

--- a/xpresso/routing/websockets.py
+++ b/xpresso/routing/websockets.py
@@ -13,7 +13,7 @@ from di.api.solved import SolvedDependant
 from di.dependant import JoinedDependant
 
 import xpresso._utils.asgi_scope_extension as asgi_scope_extension
-from xpresso.dependencies.models import Dependant
+from xpresso.dependencies.models import Depends
 
 
 class _WebSocketRoute:
@@ -58,7 +58,7 @@ class WebSocketRoute(starlette.routing.WebSocketRoute):
         endpoint: Endpoint,
         *,
         name: typing.Optional[str] = None,
-        dependencies: typing.Optional[typing.Sequence[Dependant]] = None,
+        dependencies: typing.Optional[typing.Sequence[Depends]] = None,
         execute_dependencies_concurrently: bool = False,
     ) -> None:
         super().__init__(  # type: ignore
@@ -77,7 +77,7 @@ class WebSocketRoute(starlette.routing.WebSocketRoute):
     ) -> None:
         self.dependant = container.solve(
             JoinedDependant(
-                Dependant(self.endpoint, scope="endpoint"),
+                Depends(self.endpoint, scope="endpoint"),
                 siblings=[*dependencies, *(self.dependencies or ())],
             )
         )


### PR DESCRIPTION
This save some characters in a critical area (using `Annotated[..., Dependant(...)]` can easily spill over the line length limit) and reduces the mismatch with FastAPI, which in theory makes it easier to port things over.