### PR TITLE
refactor!: change binder API to modify OpenAPI schema in place

### DIFF
--- a/docs_src/advanced/binders/msgpack/openapi.py
+++ b/docs_src/advanced/binders/msgpack/openapi.py
@@ -1,11 +1,7 @@
 import inspect
 import typing
 
-from xpresso.binders.api import (
-    ModelNameMap,
-    OpenAPIMetadata,
-    SupportsOpenAPI,
-)
+from xpresso.binders.api import ModelNameMap, SupportsOpenAPI
 from xpresso.openapi import models
 
 
@@ -13,21 +9,22 @@ class OpenAPI:
     def get_models(self) -> typing.List[type]:
         return []
 
-    def get_openapi(
-        self, model_name_map: ModelNameMap
-    ) -> OpenAPIMetadata:
-        return OpenAPIMetadata(
-            body=models.RequestBody(
-                content={
-                    "application/x-msgpack": models.MediaType(
-                        schema=models.Schema(  # type: ignore[arg-type]
-                            type="string",
-                            format="binary",
-                        )
+    def modify_operation_schema(
+        self,
+        model_name_map: ModelNameMap,
+        operation: models.Operation,
+        components: models.Components,
+    ) -> None:
+        operation.requestBody = models.RequestBody(
+            content={
+                "application/x-msgpack": models.MediaType(
+                    schema=models.Schema(  # type: ignore[arg-type]
+                        type="string",
+                        format="binary",
                     )
-                },
-                required=True,
-            )
+                )
+            },
+            required=True,
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xpresso"
-version = "0.39.0"
+version = "0.40.0"
 description = "A developer centric, performant Python web framework"
 authors = ["Adrian Garcia Badaracco <adrian@adriangb.com>"]
 readme = "README.md"

--- a/tests/test_docs/advanced/dependencies/test_tutorial_002.py
+++ b/tests/test_docs/advanced/dependencies/test_tutorial_002.py
@@ -8,7 +8,6 @@ from docs_src.advanced.dependencies.tutorial_002 import app
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("anyio_backend", ["asyncio"])
-@pytest.mark.slow
 async def test_get_slow_endpoint() -> None:
     # unforuntely it is pretty hard to actually time this in tests without making
     # really slow tests just for the sake of running timing on them

--- a/tests/test_docs/advanced/test_body_union.py
+++ b/tests/test_docs/advanced/test_body_union.py
@@ -128,16 +128,40 @@ def test_post_json():
 def test_post_unsupported_media_type():
     response = client.post("/items/", headers={"Content-Type": "text/plain"})
     assert response.status_code == 415
-    assert response.json() == {'detail': [{'loc': ['headers', 'content-type'], 'msg': 'Media type text/plain is not supported', 'type': 'value_error'}]}
+    assert response.json() == {
+        "detail": [
+            {
+                "loc": ["headers", "content-type"],
+                "msg": "Media type text/plain is not supported",
+                "type": "value_error",
+            }
+        ]
+    }
 
 
 def test_post_invalid_json():
     response = client.post("/items/", json={"name": "hammer"})
     assert response.status_code == 422
-    assert response.json() == {'detail': [{'loc': ['body', 'price'], 'msg': 'field required', 'type': 'value_error.missing'}]}
+    assert response.json() == {
+        "detail": [
+            {
+                "loc": ["body", "price"],
+                "msg": "field required",
+                "type": "value_error.missing",
+            }
+        ]
+    }
 
 
 def test_post_invalid_form():
     response = client.post("/items/", data={"name": "hammer"})
     assert response.status_code == 422
-    assert response.json() == {'detail': [{'loc': ['body', 'price'], 'msg': 'field required', 'type': 'value_error.missing'}]}
+    assert response.json() == {
+        "detail": [
+            {
+                "loc": ["body", "price"],
+                "msg": "field required",
+                "type": "value_error.missing",
+            }
+        ]
+    }

--- a/tests/test_docs/advanced/test_root_path.py
+++ b/tests/test_docs/advanced/test_root_path.py
@@ -14,11 +14,7 @@ openapi_schema: Dict[str, Any] = {
                 "responses": {
                     "200": {
                         "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {"type": "string"}
-                            }
-                        },
+                        "content": {"application/json": {"schema": {"type": "string"}}},
                     }
                 }
             }

--- a/xpresso/binders/_binders/file_body.py
+++ b/xpresso/binders/_binders/file_body.py
@@ -171,7 +171,9 @@ class OpenAPI(typing.NamedTuple):
         operation.requestBody = operation.requestBody or openapi_models.RequestBody(
             content={}
         )
-        if not isinstance(operation.requestBody, openapi_models.RequestBody):
+        if not isinstance(
+            operation.requestBody, openapi_models.RequestBody
+        ):  # pragma: no cover
             raise ValueError(
                 "Expected request body to be a RequestBody object, found a reference"
             )

--- a/xpresso/binders/_binders/form_body.py
+++ b/xpresso/binders/_binders/form_body.py
@@ -314,7 +314,9 @@ class OpenAPI(typing.NamedTuple):
         operation.requestBody = operation.requestBody or openapi_models.RequestBody(
             content={}
         )
-        if not isinstance(operation.requestBody, openapi_models.RequestBody):
+        if not isinstance(
+            operation.requestBody, openapi_models.RequestBody
+        ):  # pragma: no cover
             raise ValueError(
                 "Expected request body to be a RequestBody object, found a reference"
             )

--- a/xpresso/binders/_binders/form_body.py
+++ b/xpresso/binders/_binders/form_body.py
@@ -18,12 +18,7 @@ from xpresso.binders._binders.formencoded_parsing import (
 )
 from xpresso.binders._binders.media_type_validator import MediaTypeValidator
 from xpresso.binders._binders.pydantic_validators import validate_body_field
-from xpresso.binders.api import (
-    ModelNameMap,
-    OpenAPIMetadata,
-    SupportsExtractor,
-    SupportsOpenAPI,
-)
+from xpresso.binders.api import ModelNameMap, SupportsExtractor, SupportsOpenAPI
 from xpresso.exceptions import RequestValidationError
 from xpresso.openapi._utils import parse_examples
 from xpresso.typing import Some
@@ -308,12 +303,22 @@ class OpenAPI(typing.NamedTuple):
             for model in provider.get_models()
         ]
 
-    def get_openapi(
+    def modify_operation_schema(
         self,
         model_name_map: ModelNameMap,
-    ) -> OpenAPIMetadata:
+        operation: openapi_models.Operation,
+        components: openapi_models.Components,
+    ) -> None:
         if not self.include_in_schema:
-            return OpenAPIMetadata()
+            return
+        operation.requestBody = operation.requestBody or openapi_models.RequestBody(
+            content={}
+        )
+        if not isinstance(operation.requestBody, openapi_models.RequestBody):
+            raise ValueError(
+                "Expected request body to be a RequestBody object, found a reference"
+            )
+
         schemas: typing.Dict[str, typing.Any] = {}
         providers_openapis = {
             field_name: field_openapi.get_field_openapi(
@@ -336,18 +341,18 @@ class OpenAPI(typing.NamedTuple):
             required=self.required_fields or None,
             nullable=self.nullable or None,
         )
-        media_type = openapi_models.MediaType(
+        operation.requestBody.content[self.media_type] = openapi_models.MediaType(
             schema=schema,  # type: ignore
             examples=self.examples,
             encoding=encodings or None,
         )
-        return OpenAPIMetadata(
-            body=openapi_models.RequestBody(
-                content={self.media_type: media_type},
-                required=self.required,
-            ),
-            schemas=schemas,
+        operation.requestBody.required = operation.requestBody.required or self.required
+        operation.requestBody.description = (
+            operation.requestBody.description or self.description
         )
+        if schemas:
+            components.schemas = components.schemas or {}
+            components.schemas.update(schemas)
 
 
 class OpenAPIMarker(typing.NamedTuple):

--- a/xpresso/binders/_binders/json_body.py
+++ b/xpresso/binders/_binders/json_body.py
@@ -118,7 +118,9 @@ class OpenAPI(typing.NamedTuple):
         operation.requestBody = operation.requestBody or openapi_models.RequestBody(
             content={}
         )
-        if not isinstance(operation.requestBody, openapi_models.RequestBody):
+        if not isinstance(
+            operation.requestBody, openapi_models.RequestBody
+        ):  # pragma: no cover
             raise ValueError(
                 "Expected request body to be a RequestBody object, found a reference"
             )

--- a/xpresso/binders/_binders/union.py
+++ b/xpresso/binders/_binders/union.py
@@ -4,12 +4,7 @@ import typing
 import xpresso.openapi.models as openapi_models
 from xpresso._utils.pydantic_utils import model_field_from_param
 from xpresso._utils.typing import Annotated, get_args, get_origin
-from xpresso.binders.api import (
-    ModelNameMap,
-    OpenAPIMetadata,
-    SupportsExtractor,
-    SupportsOpenAPI,
-)
+from xpresso.binders.api import ModelNameMap, SupportsExtractor, SupportsOpenAPI
 from xpresso.binders.dependants import Binder, BinderMarker
 from xpresso.exceptions import HTTPException, RequestValidationError
 from xpresso.requests import HTTPConnection, Request
@@ -43,22 +38,14 @@ class BodyOpenAPI(typing.NamedTuple):
     def get_models(self) -> typing.List[type]:
         return [model for p in self.providers for model in p.get_models()]
 
-    def get_openapi(self, model_name_map: ModelNameMap) -> OpenAPIMetadata:
-        content: typing.Dict[str, openapi_models.MediaType] = {}
-        schemas: typing.Dict[str, typing.Any] = {}
+    def modify_operation_schema(
+        self,
+        model_name_map: ModelNameMap,
+        operation: openapi_models.Operation,
+        components: openapi_models.Components,
+    ) -> None:
         for provider in self.providers:
-            meta = provider.get_openapi(model_name_map)
-            if meta.body is None:
-                raise TypeError()
-            for k, v in meta.body.content.items():
-                if k in content:
-                    raise ValueError(f"Duplicate bodies for media type {k}")
-                content[k] = v
-            schemas.update(meta.schemas or {})
-        body = openapi_models.RequestBody(
-            required=self.required, content=content, description=self.description
-        )
-        return OpenAPIMetadata(body=body, schemas=schemas)
+            provider.modify_operation_schema(model_name_map, operation, components)
 
 
 class BodyOpenAPIMarker(typing.NamedTuple):

--- a/xpresso/openapi/models.py
+++ b/xpresso/openapi/models.py
@@ -14,12 +14,6 @@ except ImportError:  # pragma: no cover
 
 from xpresso._utils.typing import Annotated, Literal
 
-
-class FrozenBaseModel(BaseModel):
-    class Config(BaseConfig):
-        frozen = True
-
-
 ParameterLocations = Literal["header", "path", "query", "cookie"]
 PathParamStyles = Literal["simple", "label", "matrix"]
 QueryParamStyles = Literal["form", "spaceDelimited", "pipeDelimited", "deepObject"]
@@ -30,18 +24,18 @@ FormDataStyles = QueryParamStyles
 Extension = Union[Dict[str, Any], List[Any], str, int, float, bool, None]
 
 
-class Contact(FrozenBaseModel):
+class Contact(BaseModel):
     name: Optional[str] = None
     url: Optional[AnyUrl] = None
     email: Optional[EmailStr] = None
 
 
-class License(FrozenBaseModel):
+class License(BaseModel):
     name: str
     url: Optional[AnyUrl] = None
 
 
-class Info(FrozenBaseModel):
+class Info(BaseModel):
     title: str
     version: str
     description: Optional[str] = None
@@ -49,32 +43,32 @@ class Info(FrozenBaseModel):
     contact: Optional[Contact] = None
     license: Optional[License] = None
 
-    class Config(FrozenBaseModel.Config):
+    class Config(BaseConfig):
         extra = Extra.allow  # for extensions
 
 
-class ServerVariable(FrozenBaseModel):
+class ServerVariable(BaseModel):
     default: str
     enum: Optional[List[str]] = None
     description: Optional[str] = None
 
 
-class Server(FrozenBaseModel):
+class Server(BaseModel):
     url: Union[AnyUrl, str]
     description: Optional[str] = None
     variables: Optional[Dict[str, ServerVariable]] = None
 
 
-class Reference(FrozenBaseModel):
+class Reference(BaseModel):
     ref: Annotated[str, Field(alias="$ref")]
 
 
-class Discriminator(FrozenBaseModel):
+class Discriminator(BaseModel):
     propertyName: str
     mapping: Optional[Dict[str, str]] = None
 
 
-class XML(FrozenBaseModel):
+class XML(BaseModel):
     name: Optional[str] = None
     namespace: Optional[str] = None
     prefix: Optional[str] = None
@@ -82,12 +76,12 @@ class XML(FrozenBaseModel):
     wrapped: Optional[bool] = None
 
 
-class ExternalDocumentation(FrozenBaseModel):
+class ExternalDocumentation(BaseModel):
     url: AnyUrl
     description: Optional[str] = None
 
 
-class Schema(FrozenBaseModel):
+class Schema(BaseModel):
     ref: Annotated[Optional[str], Field(alias="$ref")] = None
     title: Optional[str] = None
     multipleOf: Optional[float] = None
@@ -127,7 +121,7 @@ class Schema(FrozenBaseModel):
     examples: Optional[Examples] = None
 
 
-class Example(FrozenBaseModel):
+class Example(BaseModel):
     summary: Optional[str] = None
     description: Optional[str] = None
     value: Any = None
@@ -137,20 +131,20 @@ class Example(FrozenBaseModel):
 Examples = Mapping[str, Union[Example, Reference]]
 
 
-class Encoding(FrozenBaseModel):
+class Encoding(BaseModel):
     contentType: Optional[str] = None
     headers: Optional[Dict[str, Union[Header, Reference]]] = None
     style: Optional[str] = None
     explode: Optional[bool] = None
 
 
-class MediaType(FrozenBaseModel):
+class MediaType(BaseModel):
     schema_: Annotated[Optional[Union[Schema, Reference]], Field(alias="schema")]
     examples: Optional[Examples] = None
     encoding: Optional[Dict[str, Encoding]] = None
 
 
-class ParameterBase(FrozenBaseModel):
+class ParameterBase(BaseModel):
     description: Optional[str] = None
     required: Optional[bool] = None
     deprecated: Optional[bool] = None
@@ -196,13 +190,13 @@ class Cookie(ConcreteParameter):
 Parameter = Union[Query, Header, Cookie, Path]
 
 
-class RequestBody(FrozenBaseModel):
+class RequestBody(BaseModel):
     content: Dict[str, MediaType]
     description: Optional[str] = None
     required: Optional[bool] = None
 
 
-class Link(FrozenBaseModel):
+class Link(BaseModel):
     operationRef: Optional[str] = None
     operationId: Optional[str] = None
     parameters: Optional[Dict[str, str]] = None
@@ -211,7 +205,7 @@ class Link(FrozenBaseModel):
     server: Optional[Server] = None
 
 
-class ResponseHeader(FrozenBaseModel):
+class ResponseHeader(BaseModel):
     description: Optional[str] = None
     deprecated: Optional[bool] = None
     # Serialization rules for simple scenarios
@@ -223,14 +217,14 @@ class ResponseHeader(FrozenBaseModel):
     content: Optional[Dict[str, MediaType]] = None
 
 
-class Response(FrozenBaseModel):
+class Response(BaseModel):
     description: str
     headers: Optional[Dict[str, Union[ResponseHeader, Reference]]] = None
     content: Optional[Dict[str, MediaType]] = None
     links: Optional[Dict[str, Union[Link, Reference]]] = None
 
 
-class Operation(FrozenBaseModel):
+class Operation(BaseModel):
     responses: Dict[str, Union[Response, Reference]]
     tags: Optional[List[str]] = None
     summary: Optional[str] = None
@@ -245,11 +239,11 @@ class Operation(FrozenBaseModel):
     security: Optional[List[Dict[str, List[str]]]] = None
     servers: Optional[List[Server]] = None
 
-    class Config(FrozenBaseModel.Config):
+    class Config(BaseConfig):
         extra = Extra.allow  # for extensions
 
 
-class PathItem(FrozenBaseModel):
+class PathItem(BaseModel):
     ref: Annotated[Optional[str], Field(alias="$ref")] = None
     summary: Optional[str] = None
     description: Optional[str] = None
@@ -264,14 +258,14 @@ class PathItem(FrozenBaseModel):
     servers: Optional[List[Server]] = None
     parameters: Optional[List[Union[Parameter, Reference]]] = None
 
-    class Config(FrozenBaseModel.Config):
+    class Config(BaseConfig):
         extra = Extra.allow  # for extensions
 
 
 SecuritySchemeName = Literal["apiKey", "http", "oauth2", "openIdConnect"]
 
 
-class SecurityBase(FrozenBaseModel):
+class SecurityBase(BaseModel):
     type: SecuritySchemeName
     description: Optional[str] = None
 
@@ -295,7 +289,7 @@ class HTTPBearer(HTTPBase):
     bearerFormat: Optional[str] = None
 
 
-class OAuthFlow(FrozenBaseModel):
+class OAuthFlow(BaseModel):
     refreshUrl: Optional[AnyUrl] = None
     scopes: Annotated[Optional[Mapping[str, str]], Field(default_factory=dict)]
 
@@ -317,7 +311,7 @@ class OAuthFlowAuthorizationCode(OAuthFlow):
     tokenUrl: str
 
 
-class OAuthFlows(FrozenBaseModel):
+class OAuthFlows(BaseModel):
     implicit: Optional[OAuthFlowImplicit] = None
     password: Optional[OAuthFlowPassword] = None
     clientCredentials: Optional[OAuthFlowClientCredentials] = None
@@ -337,7 +331,7 @@ class OpenIdConnect(SecurityBase):
 SecurityScheme = Union[APIKey, HTTPBase, OAuth2, OpenIdConnect, HTTPBearer]
 
 
-class Components(FrozenBaseModel):
+class Components(BaseModel):
     schemas: Optional[Dict[str, Union[Schema, Reference]]] = None
     responses: Optional[Dict[str, Union[Response, Reference]]] = None
     parameters: Optional[Dict[str, Union[Parameter, Reference]]] = None
@@ -349,13 +343,13 @@ class Components(FrozenBaseModel):
     callbacks: Optional[Dict[str, Union[Dict[str, PathItem], Reference]]] = None
 
 
-class Tag(FrozenBaseModel):
+class Tag(BaseModel):
     name: str
     description: Optional[str] = None
     externalDocs: Optional[ExternalDocumentation] = None
 
 
-class OpenAPI(FrozenBaseModel):
+class OpenAPI(BaseModel):
     openapi: str
     info: Info
     paths: Annotated[Dict[str, Union[PathItem, Extension]], Field(default_factory=dict)]


### PR DESCRIPTION
This paves the path for more OpenAPI generation (security models and such) without bloating the API, at the cost of shifting some responsibilies to each implementer instead of centralizing them in the OpenAPI generation infra