### PR TITLE
don't run sync dependencies in threads by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xpresso"
-version = "0.42.4"
+version = "0.43.0"
 description = "A developer centric, performant Python web framework"
 authors = ["Adrian Garcia Badaracco <adrian@adriangb.com>"]
 readme = "README.md"

--- a/xpresso/_utils/endpoint_dependant.py
+++ b/xpresso/_utils/endpoint_dependant.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import typing
 
 from di.api.providers import CallableProvider, CoroutineProvider
+from di.concurrency import as_async
 from di.dependant import Dependant
 
 from xpresso.dependencies._dependencies import Depends, DependsMarker
@@ -16,12 +17,13 @@ class EndpointDependant(Dependant[typing.Any]):
         endpoint: Endpoint,
         sync_to_thread: bool = False,
     ) -> None:
+        if sync_to_thread:
+            endpoint = as_async(endpoint)
         super().__init__(
             call=endpoint,
             scope="endpoint",
             use_cache=False,
             wire=True,
-            sync_to_thread=sync_to_thread,
         )
 
     def get_default_marker(self) -> DependsMarker[None]:

--- a/xpresso/_utils/overrides.py
+++ b/xpresso/_utils/overrides.py
@@ -39,7 +39,6 @@ class DependencyOverrideManager:
                 scope=scope,  # type: ignore[arg-type]
                 use_cache=dependant.use_cache,
                 wire=dependant.wire,
-                sync_to_thread=dependant.sync_to_thread,
             )
             if param is not None and param.annotation is not param.empty:
                 type_ = get_type(param)

--- a/xpresso/dependencies/_dependencies.py
+++ b/xpresso/dependencies/_dependencies.py
@@ -1,3 +1,4 @@
+import inspect
 import typing
 
 from di.api.providers import DependencyProvider
@@ -69,7 +70,7 @@ class DependsMarker(Marker, typing.Generic[DependencyType]):
         *,
         use_cache: bool = True,
         wire: bool = True,
-        sync_to_thread: bool = True,
+        sync_to_thread: bool = False,
         scope: typing.Optional[Scope] = None,
     ) -> None:
         super().__init__(
@@ -77,16 +78,27 @@ class DependsMarker(Marker, typing.Generic[DependencyType]):
             scope=scope,
             use_cache=use_cache,
             wire=wire,
-            sync_to_thread=sync_to_thread,
         )
+        self.sync_to_thread = sync_to_thread
 
     def as_dependant(self) -> Dependant[DependencyType]:
+        call: "typing.Optional[DependencyProvider]"
+        if self.sync_to_thread:
+            if not (
+                inspect.isasyncgenfunction(self.call)
+                or inspect.iscoroutinefunction(self.call)
+            ):
+                raise ValueError(
+                    "sync_to_thread can only be used if you explicitly declare the target function"
+                )
+            call = as_async(self.call)
+        else:
+            call = self.call
         return Dependant(
-            call=self.call,
+            call=call,  # type: ignore
             scope=self.scope,
             use_cache=self.use_cache,
             wire=self.wire,
-            sync_to_thread=self.sync_to_thread,
             marker=self,
         )
 

--- a/xpresso/dependencies/_dependencies.py
+++ b/xpresso/dependencies/_dependencies.py
@@ -1,4 +1,3 @@
-import inspect
 import typing
 
 from di.api.providers import DependencyProvider
@@ -84,10 +83,7 @@ class DependsMarker(Marker, typing.Generic[DependencyType]):
     def as_dependant(self) -> Dependant[DependencyType]:
         call: "typing.Optional[DependencyProvider]"
         if self.sync_to_thread:
-            if not (
-                inspect.isasyncgenfunction(self.call)
-                or inspect.iscoroutinefunction(self.call)
-            ):
+            if not self.call:
                 raise ValueError(
                     "sync_to_thread can only be used if you explicitly declare the target function"
                 )

--- a/xpresso/routing/operation.py
+++ b/xpresso/routing/operation.py
@@ -101,7 +101,7 @@ class Operation(BaseRoute):
             typing.Callable[[typing.Any], Response]
         ] = None,
         response_encoder: typing.Optional[Encoder] = JsonableEncoder(),
-        sync_to_thread: bool = True,
+        sync_to_thread: bool = False,
         # responses
         response_status_code: int = 200,
         response_media_type: str = "application/json",


### PR DESCRIPTION
Not modifying the code that users give us by default seems like the most sensible thing to do.