### PR TITLE
feat!: rename FromFile and File to FromRawBody and RawBody

### DIFF
--- a/docs/tutorial/body.md
+++ b/docs/tutorial/body.md
@@ -57,14 +57,14 @@ First, import `Field` from Pydantic and `Annotated`:
     All it does is import `Annotated` from `typing` if your Python version is >= 3.9 and [typing_extensions] otherwise.
     But if you are already using Python >= 3.9, you can just replace that with `from typing import Annotated`.
 
-Now use `Field()` inside of `Annotated[...]` to attach validation and schema customziation metadata to the `price` field:
+Now use `Field()` inside of `Annotated[...]` to attach validation and schema customization metadata to the `price` field:
 
 ```python hl_lines="11-17"
 --8<-- "docs_src/tutorial/body/tutorial_002.py"
 ```
 
 !!! tip "Tip"
-    Pydantic also supports the syntax `field_name: str = Field(...)`, but we encourage youto get used to using `Annotated` instead.
+    Pydantic also supports the syntax `field_name: str = Field(...)`, but we encourage you to get used to using `Annotated` instead.
     As you will see in later chapters about forms and multipart requests, this will allow you to mix in Pydantic's validation and schema customization with Xpresso's extractor system.
     That said, for JSON bodies using `field_name: str = Field(...)` will work just fine.
 
@@ -96,5 +96,20 @@ You can add examples via the `examples` keyword to `Json()`, `FormData()` or `Mu
 The Swagger docs will now reflect this:
 
 ![Swagger UI](body_002.png)
+
+## Raw bytes
+
+To extract the raw bytes from the body (without validating it as JSON) see [Files](files.md).
+
+## Consuming of the request body
+
+By default Xpresso will _consume_ the request body.
+This is the equivalent of calling `Request.steam()` until completion.
+When you only need to extract the body once this is probably what you want since it avoids keeping around extra memory that goes unused.
+If you want to extract the request body and still have access to it in another extractor or via `Request` you need to set `consume=False` as an argument to `Json`:
+
+```python hl_lines="15 16"
+--8<-- "docs_src/tutorial/body/tutorial_006.py"
+```
 
 [Pydantic]: https://pydantic-docs.helpmanual.io

--- a/docs/tutorial/files.md
+++ b/docs/tutorial/files.md
@@ -1,6 +1,6 @@
 # Files
 
-You can read the request body directly into a file or bytes.
+You can read the raw request body directly into a file or bytes.
 This will read the data from the top level request body, and can only support 1 file.
 To receive multiple files, see the [multipart/form-data documentation].
 
@@ -35,7 +35,7 @@ If you want to read the bytes without buffering to disk or memory, use `AsyncIte
 
 ## Setting the expected content-type
 
-You can set the media type via the `media_type` parameter to `File()` and enforce it via the `enforce_media_type` parameter:
+You can set the media type via the `media_type` parameter to `RawBody()` and enforce it via the `enforce_media_type` parameter:
 
 ```python
 --8<-- "docs_src/tutorial/files/tutorial_004.py"
@@ -44,6 +44,6 @@ You can set the media type via the `media_type` parameter to `File()` and enforc
 Media types can be a media type (e.g. `image/png`) or a media type range (e.g. `image/*`).
 
 If you do not explicitly set the media type, all media types are accepted.
-Once you set an explicit media type, that media type in the requests' `Content-Type` header will be validated on incoming requests, but this behavior can be disabled via the `enforce_media_type` parameter to `File()`.
+Once you set an explicit media type, that media type in the requests' `Content-Type` header will be validated on incoming requests, but this behavior can be disabled via the `enforce_media_type` parameter to `RawBody()`.
 
 [multipart/form-data documentation]: forms.md#multipart-requests

--- a/docs_src/tutorial/body/tutorial_006.py
+++ b/docs_src/tutorial/body/tutorial_006.py
@@ -1,14 +1,8 @@
 import json
 from typing import Any, Dict
 
-from pydantic import BaseModel
-
 from xpresso import App, Json, Path, RawBody
 from xpresso.typing import Annotated
-
-
-class WebhookBody(BaseModel):
-    name: str
 
 
 async def handle_event(

--- a/docs_src/tutorial/body/tutorial_006.py
+++ b/docs_src/tutorial/body/tutorial_006.py
@@ -1,0 +1,28 @@
+import json
+from typing import Any, Dict
+
+from pydantic import BaseModel
+
+from xpresso import App, Json, Path, RawBody
+from xpresso.typing import Annotated
+
+
+class WebhookBody(BaseModel):
+    name: str
+
+
+async def handle_event(
+    event: Annotated[Dict[str, Any], Json(consume=False)],
+    raw_body: Annotated[bytes, RawBody(consume=False)],
+) -> bool:
+    return json.loads(raw_body) == event
+
+
+app = App(
+    routes=[
+        Path(
+            "/webhook",
+            post=handle_event,
+        )
+    ]
+)

--- a/docs_src/tutorial/files/tutorial_001.py
+++ b/docs_src/tutorial/files/tutorial_001.py
@@ -1,7 +1,7 @@
-from xpresso import App, FromFile, Path, UploadFile
+from xpresso import App, FromRawBody, Path, UploadFile
 
 
-async def count_bytes_in_file(file: FromFile[UploadFile]) -> int:
+async def count_bytes_in_file(file: FromRawBody[UploadFile]) -> int:
     return len(await file.read())
 
 

--- a/docs_src/tutorial/files/tutorial_002.py
+++ b/docs_src/tutorial/files/tutorial_002.py
@@ -1,7 +1,7 @@
-from xpresso import App, FromFile, Path
+from xpresso import App, FromRawBody, Path
 
 
-async def count_bytes_in_file(data: FromFile[bytes]) -> int:
+async def count_bytes_in_file(data: FromRawBody[bytes]) -> int:
     return len(data)
 
 

--- a/docs_src/tutorial/files/tutorial_003.py
+++ b/docs_src/tutorial/files/tutorial_003.py
@@ -1,10 +1,10 @@
 from typing import AsyncIterator
 
-from xpresso import App, FromFile, Path
+from xpresso import App, FromRawBody, Path
 
 
 async def count_bytes_in_file(
-    data: FromFile[AsyncIterator[bytes]],
+    data: FromRawBody[AsyncIterator[bytes]],
 ) -> int:
     size = 0
     async for chunk in data:

--- a/docs_src/tutorial/files/tutorial_004.py
+++ b/docs_src/tutorial/files/tutorial_004.py
@@ -1,11 +1,11 @@
-from xpresso import App, File, Path, UploadFile
+from xpresso import App, Path, RawBody, UploadFile
 from xpresso.typing import Annotated
 
 
 async def count_image_bytes(
     file: Annotated[
         UploadFile,
-        File(media_type="image/*", enforce_media_type=True),
+        RawBody(media_type="image/*", enforce_media_type=True),
     ]
 ) -> int:
     return len(await file.read())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xpresso"
-version = "0.45.1"
+version = "0.46.0"
 description = "A developer centric, performant Python web framework"
 authors = ["Adrian Garcia Badaracco <adrian@adriangb.com>"]
 readme = "README.md"

--- a/tests/test_docs/tutorial/body/test_tutorial_006.py
+++ b/tests/test_docs/tutorial/body/test_tutorial_006.py
@@ -1,0 +1,10 @@
+from docs_src.tutorial.body.tutorial_006 import app
+from xpresso.testclient import TestClient
+
+client = TestClient(app)
+
+
+def test_body_tutorial_006():
+    response = client.post("/webhook", json={"foo": "bar"})
+    assert response.status_code == 200, response.content
+    assert response.json() is True

--- a/tests/test_routing/test_operation.py
+++ b/tests/test_routing/test_operation.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 import pytest
 import starlette.routing
 
-from xpresso import App, FromFile, FromJson, Operation, Path
+from xpresso import App, FromJson, FromRawBody, Operation, Path
 from xpresso.routing.operation import NotPreparedError
 from xpresso.testclient import TestClient
 
@@ -44,7 +44,7 @@ def test_operation_comparison() -> None:
 @pytest.mark.skip
 def test_multiple_bodies_are_not_allowed() -> None:
     async def endpoint(
-        body1: FromFile[bytes],
+        body1: FromRawBody[bytes],
         body2: FromJson[str],
     ) -> None:
         raise AssertionError("Should not be called")  # pragma: no cover

--- a/xpresso/__init__.py
+++ b/xpresso/__init__.py
@@ -14,11 +14,14 @@ from xpresso.bodies import (
     FromFormFile,
     FromJson,
     FromMultipart,
-    FromRawBody,
-    Json,
-    Multipart,
-    RawBody,
 )
+from xpresso.bodies import FromRawBody
+from xpresso.bodies import FromRawBody as FromFile
+from xpresso.bodies import Json, Multipart
+from xpresso.bodies import (
+    RawBody,  # backwards compatibility aliases; TODO: remove in a couple of releases
+)
+from xpresso.bodies import RawBody as File
 from xpresso.datastructures import UploadFile
 from xpresso.dependencies import Depends
 from xpresso.exception_handlers import ExcHandler
@@ -75,4 +78,8 @@ __all__ = (
     "Response",
     "WebSocketRoute",
     "WebSocket",
+    # backwards compatibility aliases
+    # TODO: remove in a couple of releases
+    "File",
+    "FromFile",
 )

--- a/xpresso/__init__.py
+++ b/xpresso/__init__.py
@@ -5,19 +5,19 @@ from starlette.responses import Response
 from xpresso.applications import App
 from xpresso.bodies import (
     BodyUnion,
-    File,
     Form,
     FormField,
     FormFile,
     FromBodyUnion,
-    FromFile,
     FromFormData,
     FromFormField,
     FromFormFile,
     FromJson,
     FromMultipart,
+    FromRawBody,
     Json,
     Multipart,
+    RawBody,
 )
 from xpresso.datastructures import UploadFile
 from xpresso.dependencies import Depends
@@ -51,7 +51,7 @@ __all__ = (
     "FormFile",
     "FromFormFile",
     "Form",
-    "File",
+    "RawBody",
     "Multipart",
     "Depends",
     "App",
@@ -69,7 +69,7 @@ __all__ = (
     "FromPath",
     "FromQuery",
     "HTTPException",
-    "FromFile",
+    "FromRawBody",
     "status",
     "Request",
     "Response",

--- a/xpresso/__init__.py
+++ b/xpresso/__init__.py
@@ -4,6 +4,9 @@ from starlette.responses import Response
 
 from xpresso.applications import App
 from xpresso.bodies import (
+    RawBody,  # backwards compatibility aliases; TODO: remove in a couple of releases
+)
+from xpresso.bodies import (
     BodyUnion,
     Form,
     FormField,
@@ -18,10 +21,6 @@ from xpresso.bodies import (
 from xpresso.bodies import FromRawBody
 from xpresso.bodies import FromRawBody as FromFile
 from xpresso.bodies import Json, Multipart
-from xpresso.bodies import (
-    RawBody,  # backwards compatibility aliases; TODO: remove in a couple of releases
-)
-from xpresso.bodies import RawBody as File
 from xpresso.datastructures import UploadFile
 from xpresso.dependencies import Depends
 from xpresso.exception_handlers import ExcHandler

--- a/xpresso/bodies.py
+++ b/xpresso/bodies.py
@@ -34,7 +34,7 @@ def Json(
     )
 
 
-def File(
+def RawBody(
     *,
     media_type: typing.Optional[str] = None,
     enforce_media_type: bool = True,
@@ -158,12 +158,34 @@ def BodyUnion(
     )
 
 
+if typing.TYPE_CHECKING:
+    from pydantic import BaseModel
+
+    from xpresso import UploadFile
+
+
 # Convenience type aliases
 _T = typing.TypeVar("_T")
-FromJson = Annotated[_T, Json()]
-FromFile = Annotated[_T, File()]
+_BaseModelT = typing.TypeVar("_BaseModelT", bound=typing.Union["BaseModel", None])
+FromJson = Annotated[_BaseModelT, Json()]
+_BinaryT = typing.TypeVar(
+    "_BinaryT",
+    bound=typing.Union[
+        bytes,
+        "UploadFile",
+        typing.AsyncIterator[bytes],
+        None,
+    ],
+)
+FromRawBody = Annotated[_BinaryT, RawBody()]
 FromFormField = Annotated[_T, FormField()]
-FromFormFile = Annotated[_T, FormFile()]
-FromFormData = Annotated[_T, Form()]
-FromMultipart = Annotated[_T, Multipart()]
+_FormFileT = typing.TypeVar(
+    "_FormFileT",
+    bound=typing.Union[
+        bytes, "UploadFile", typing.List[bytes], "typing.List[UploadFile]", None
+    ],
+)
+FromFormFile = Annotated[_FormFileT, FormFile()]
+FromFormData = Annotated[_BaseModelT, Form()]
+FromMultipart = Annotated[_BaseModelT, Multipart()]
 FromBodyUnion = Annotated[_T, BodyUnion()]


### PR DESCRIPTION
This is a breaking change that renames a couple symbols to disambiguate their usage.